### PR TITLE
Fix multiline variant declarations without terminal semicolon

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -59,9 +59,7 @@ module.exports = grammar({
     [$.record_field, $.record_pattern],
     [$.primary_expression, $.spread_pattern],
     [$.primary_expression, $._literal_pattern],
-    [$.expression_statement, $.switch_match],
     [$.expression_statement, $.ternary_expression],
-    [$.expression_statement, $.switch_match, $.ternary_expression],
     [$.let_binding, $.ternary_expression],
     [$.variant_identifier, $.module_name],
     [$.variant],
@@ -100,7 +98,10 @@ module.exports = grammar({
 
     block: $ => prec.right(seq(
       '{',
-      repeat($._statement),
+      optional(seq(
+        repeat($._statement),
+        $.statement
+      )),
       '}',
     )),
 
@@ -200,7 +201,6 @@ module.exports = grammar({
       $.variant_identifier,
       optional($.variant_parameters),
       optional($.type_annotation),
-      optional($._newline),
     )),
 
     variant_parameters: $ => seq(
@@ -466,13 +466,13 @@ module.exports = grammar({
     ),
 
     switch_match: $ => seq(
-      '|',
-      barSep1($._switch_pattern),
+      repeat1($._switch_pattern),
       '=>',
-      repeat1($._statement),
+      $._switch_match_body,
     ),
 
     _switch_pattern: $ => seq(
+      '|',
       choice(
         $.pattern,
         $._literal_pattern,
@@ -484,6 +484,11 @@ module.exports = grammar({
     switch_pattern_condition: $ => seq(
       'if',
       $.expression,
+    ),
+
+    _switch_match_body: $ => seq(
+      repeat($._statement),
+      $.statement,
     ),
 
     as_aliasing: $ => seq(

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -123,8 +123,16 @@ bool tree_sitter_rescript_external_scanner_scan(
         // Ignore new lines before pipe operator (->)
         return false;
       }
+    } else if (lexer->lookahead == '|') {
+      // Ignore new lines before variant declarations and switch matches
+      return false;
     } else if (lexer->lookahead == '?' || lexer->lookahead == ':') {
       // Ignore new lines before potential ternaries
+      return false;
+    } else if (lexer->lookahead == '}') {
+      // Do not report new lines right before block/switch closings to avoid
+      // parser confustion between a terminated and unterminated statements
+      // for rules like seq(repeat($._statement), $.statement)
       return false;
     }
 

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -63,7 +63,7 @@ Variant
 type t =
   | A
   | B(anotherType)
-  | C({foo: int, bar: string});
+  | C({foo: int, bar: string})
 
 ---
 
@@ -88,7 +88,7 @@ type t =
 Annotated variant
 ===========================================
 
-type rec t = Any('a): t;
+type rec t = Any('a): t
 
 ---
 


### PR DESCRIPTION
Previously a multiline variant:

```
type e =
  | A
  | B
```

required a trailing `;`. Now it is not.