### PR TITLE
Exception patterns in switch matches

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -470,6 +470,18 @@ module.exports = grammar({
     _switch_pattern: $ => seq(
       '|',
       choice(
+        alias($._switch_exception_pattern, $.exception),
+        $._switch_value_pattern,
+      ),
+    ),
+
+    _switch_exception_pattern: $ => seq(
+      'exception',
+      $._switch_value_pattern,
+    ),
+
+    _switch_value_pattern: $ => seq(
+      choice(
         $.pattern,
         $._literal_pattern,
       ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -94,6 +94,7 @@
   "external"
   "module"
   "as"
+  "exception"
 ] @keyword
 
 [

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -482,6 +482,29 @@ switch foo {
         (expression_statement (number))))))
 
 ===========================================
+Switch exceptions
+===========================================
+
+switch parseExn(str) {
+| json => 42
+| exception Js.Exn.Error(obj) => 99
+}
+
+---
+
+(source_file
+  (expression_statement
+    (switch_expression
+      (call_expression (identifier) (arguments (identifier)))
+      (switch_match (identifier) (expression_statement (number)))
+      (switch_match
+        (exception
+          (variant_pattern
+            (nested_variant_identifier (module_name) (module_name) (variant_identifier))
+            (formal_parameters (identifier))))
+        (expression_statement (number))))))
+
+===========================================
 Math operators
 ===========================================
 

--- a/test/highlight/expressions.res
+++ b/test/highlight/expressions.res
@@ -9,6 +9,8 @@ switch foo {
 //              ^ parameter
 //                    ^ punctuation.special
   42
+| exception Js.Exn.Error(_) => 99
+//^ keyword
 }
 
 { foo, bar: baz, qux: 1 }


### PR DESCRIPTION
```rescript
let maybeJson = switch Js.Json.parseExn(str) {
| json => Ok(json)
| exception Js.Exn.Error(obj) =>
  let message = Js.Exn.message(obj)
  Error(#SyntaxError(message->Option.getWithDefault("Syntax error")))
}
```