### PR TITLE
Localize bad switch damage

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -459,15 +459,15 @@ module.exports = grammar({
       'switch',
       $.expression,
       '{',
-      repeat1($.switch_match),
+      repeat($.switch_match),
       '}',
     ),
 
-    switch_match: $ => seq(
+    switch_match: $ => prec.dynamic(-1, seq(
       repeat1($._switch_pattern),
       '=>',
       $._switch_match_body,
-    ),
+    )),
 
     _switch_pattern: $ => seq(
       '|',

--- a/test/corpus/error_scopes.txt
+++ b/test/corpus/error_scopes.txt
@@ -1,0 +1,20 @@
+===========================================
+Limit switch damage
+===========================================
+
+switch foo {
+| 7 => 42
+| zhopa-priehali?
+}
+
+let x = 5
+
+---
+
+(source_file
+  (expression_statement
+    (switch_expression
+      (identifier)
+      (switch_match (number) (expression_statement (number)))
+      (ERROR (identifier) (UNEXPECTED 'p'))))
+  (let_binding (identifier) (number)))


### PR DESCRIPTION
Malformed (typing now) switch expressions no longer cause the rest of the file parse crazy