### PR TITLE
Refactor: consistent naming of nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -41,7 +41,7 @@ module.exports = grammar({
     ],
     [$._jsx_attribute_value, $.pipe_expression],
     [$.function_type_parameters, $.function_type],
-    [$.nested_module_expression, $.module_type_of],
+    [$.module_identifier_path, $.module_type_of],
   ],
 
   conflicts: $ => [
@@ -51,7 +51,7 @@ module.exports = grammar({
     [$.tuple_pattern, $._formal_parameter],
     [$.primary_expression, $._formal_parameter],
     [$.primary_expression, $.record_field],
-    [$.nested_module_expression, $.module_expression],
+    [$.module_identifier_path, $.module_expression],
     [$.tuple_type, $._function_type_parameter],
     [$.list, $.list_pattern],
     [$.array, $.array_pattern],
@@ -60,7 +60,7 @@ module.exports = grammar({
     [$.primary_expression, $._literal_pattern],
     [$.expression_statement, $.ternary_expression],
     [$.let_binding, $.ternary_expression],
-    [$.variant_identifier, $.module_name],
+    [$.variant_identifier, $.module_identifier],
     [$.variant],
     [$.variant, $.variant_pattern],
     [$.polyvar],
@@ -127,7 +127,7 @@ module.exports = grammar({
 
     module_declaration: $ => seq(
       'module',
-      $.module_name,
+      $.module_identifier,
       optional(seq(
         ':',
         field('signature', choice($.block, $.module_expression)),
@@ -140,7 +140,7 @@ module.exports = grammar({
 
     external_declaration: $ => seq(
       'external',
-      $.identifier,
+      $.value_identifier,
       $.type_annotation,
       '=',
       $.string,
@@ -181,7 +181,7 @@ module.exports = grammar({
     ),
 
     _non_function_inline_type: $ => choice(
-      $._qualified_type_identifier,
+      $._type_identifier,
       $.tuple_type,
       $.polyvar_type,
       $.object_type,
@@ -238,7 +238,7 @@ module.exports = grammar({
 
     record_type_field: $ => seq(
       repeat($.decorator),
-      alias($.identifier, $.property_identifier),
+      alias($.value_identifier, $.property_identifier),
       $.type_annotation,
     ),
 
@@ -261,7 +261,7 @@ module.exports = grammar({
     ),
 
     generic_type: $ => seq(
-      $._qualified_type_identifier,
+      $._type_identifier,
       $.type_arguments
     ),
 
@@ -316,8 +316,8 @@ module.exports = grammar({
 
     primary_expression: $ => choice(
       $.parenthesized_expression,
-      $.module_nested_identifier,
-      $.identifier,
+      $.value_identifier_path,
+      $.value_identifier,
       $.number,
       $.string,
       $.template_string,
@@ -348,14 +348,14 @@ module.exports = grammar({
       ')'
     ),
 
-    module_nested_identifier: $ => seq(
-      repeat1(seq($.module_name, '.')),
-      $.identifier,
+    value_identifier_path: $ => seq(
+      repeat1(seq($.module_identifier, '.')),
+      $.value_identifier,
     ),
 
     function: $ => prec.left(seq(
       choice(
-        field('parameter', $.identifier),
+        field('parameter', $.value_identifier),
         $._definition_signature
       ),
       '=>',
@@ -380,7 +380,7 @@ module.exports = grammar({
     ),
 
     record_field: $ => seq(
-      alias($.identifier, $.property_identifier),
+      alias($.value_identifier, $.property_identifier),
       optional(seq(
         ':',
         $.expression,
@@ -388,7 +388,7 @@ module.exports = grammar({
     ),
 
     _record_single_field: $ => seq(
-      alias($.identifier, $.property_identifier),
+      alias($.value_identifier, $.property_identifier),
       ':',
       $.expression,
       optional(','),
@@ -505,7 +505,7 @@ module.exports = grammar({
 
     as_aliasing: $ => seq(
       'as',
-      $.identifier,
+      $.value_identifier,
     ),
 
     call_expression: $ => prec('call', seq(
@@ -517,8 +517,8 @@ module.exports = grammar({
       $.primary_expression,
       choice('->', '|>'),
       choice(
-        $.identifier,
-        $.module_nested_identifier,
+        $.value_identifier,
+        $.value_identifier_path,
         choice($.variant_identifier, $.nested_variant_identifier),
       ),
     )),
@@ -535,7 +535,7 @@ module.exports = grammar({
 
     labeled_argument: $ => seq(
       '~',
-      field('label', $.identifier),
+      field('label', $.value_identifier),
       optional(choice(
         '?',
         seq(
@@ -579,7 +579,7 @@ module.exports = grammar({
 
     labeled_parameter: $ => seq(
       '~',
-      $.identifier,
+      $.value_identifier,
       optional($.as_aliasing),
       optional($.type_annotation),
       optional(field('default_value', $._labeled_parameter_default_value)),
@@ -597,7 +597,7 @@ module.exports = grammar({
     // unfinished constructs are generally treated as literal expressions,
     // not patterns.
     pattern: $ => prec.dynamic(-1, choice(
-      $.identifier,
+      $.value_identifier,
       $._destructuring_pattern,
     )),
 
@@ -660,7 +660,7 @@ module.exports = grammar({
     record_pattern: $ => seq(
       '{',
       commaSep1t(seq(
-        alias($.identifier, $.shorthand_property_identifier_pattern),
+        alias($.value_identifier, $.shorthand_property_identifier_pattern),
         optional(seq(
           ':',
           $.pattern,
@@ -702,7 +702,7 @@ module.exports = grammar({
 
     spread_pattern: $ => seq(
       '...',
-      $.identifier,
+      $.value_identifier,
     ),
 
     _jsx_element: $ => choice($.jsx_element, $.jsx_self_closing_element),
@@ -725,7 +725,7 @@ module.exports = grammar({
     ),
 
     _jsx_child: $ => choice(
-      $.identifier,
+      $.value_identifier,
       $._jsx_element,
       $.jsx_fragment,
       $.jsx_expression
@@ -739,7 +739,7 @@ module.exports = grammar({
     )),
 
     _jsx_identifier: $ => alias(
-      choice($.identifier, $.module_name),
+      choice($.value_identifier, $.module_identifier),
       $.jsx_identifier
     ),
 
@@ -769,7 +769,7 @@ module.exports = grammar({
       '>'
     ),
 
-    _jsx_attribute_name: $ => alias($.identifier, $.property_identifier),
+    _jsx_attribute_name: $ => alias($.value_identifier, $.property_identifier),
 
     jsx_attribute: $ => seq(
       optional('?'),
@@ -793,7 +793,7 @@ module.exports = grammar({
     ),
 
     _mutation_lvalue: $ => choice(
-      $.identifier,
+      $.value_identifier,
       $.member_expression,
       $.subscript_expression,
     ),
@@ -814,7 +814,7 @@ module.exports = grammar({
     member_expression: $ => prec('member', seq(
       field('record', $.primary_expression),
       '.',
-      field('property', alias($.identifier, $.property_identifier)),
+      field('property', alias($.value_identifier, $.property_identifier)),
     )),
 
     spread_element: $ => seq('...', $.expression),
@@ -888,7 +888,7 @@ module.exports = grammar({
     )),
 
     nested_variant_identifier: $ => seq(
-      repeat1(seq($.module_name, '.')),
+      repeat1(seq($.module_identifier, '.')),
       $.variant_identifier
     ),
 
@@ -904,27 +904,27 @@ module.exports = grammar({
       optional(alias($.variant_arguments, $.arguments)),
     ),
 
-    _qualified_type_identifier: $ =>
+    _type_identifier: $ =>
       choice(
         $.type_identifier,
-        $.nested_type_identifier
+        $.type_identifier_path,
       ),
 
-    nested_type_identifier: $ => seq(
-      repeat1(seq($.module_name, '.')),
+    type_identifier_path: $ => seq(
+      repeat1(seq($.module_identifier, '.')),
       $.type_identifier
     ),
 
     module_expression: $ => choice(
-      $.module_name,
-      $.nested_module_expression,
+      $.module_identifier,
+      $.module_identifier_path,
       $.module_type_of,
     ),
 
-    nested_module_expression: $ => prec.left(seq(
+    module_identifier_path: $ => prec.left(seq(
       $.module_expression,
       '.',
-      $.module_expression,
+      $.module_identifier,
     )),
 
     module_type_of: $ => prec.dynamic(-1, seq(
@@ -949,14 +949,14 @@ module.exports = grammar({
 
     type_identifier: $ => /[a-z_'][a-zA-Z0-9_]*/,
 
-    identifier: $ => choice(
+    value_identifier: $ => choice(
       /[a-z_][a-zA-Z0-9_']*/,
       $._escape_identifier,
     ),
 
     _escape_identifier: $ => token(seq('\\', '"', /[^"]+/ , '"')),
 
-    module_name: $ => /[A-Z][a-zA-Z0-9_]*/,
+    module_identifier: $ => /[A-Z][a-zA-Z0-9_]*/,
 
     decorator_identifier: $ => /[a-zA-Z0-9_\.]+/,
 
@@ -1059,7 +1059,7 @@ module.exports = grammar({
     ),
 
     template_substitution: $ => choice(
-      seq('$', $.identifier),
+      seq('$', $.value_identifier),
       seq('${', $.expression, '}'),
     ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -4,7 +4,7 @@
 ;------------
 
 ; Escaped identifiers like \"+."
-((identifier) @constant.macro
+((value_identifier) @constant.macro
  (#match? @constant.macro "^\\.*$"))
 
 [
@@ -19,7 +19,7 @@
 ] @constant
 
 (property_identifier) @property
-(module_name) @namespace
+(module_identifier) @namespace
 
 (jsx_identifier) @tag
 (jsx_attribute (property_identifier) @attribute)
@@ -28,8 +28,8 @@
 ;----------------
 
 (shorthand_property_identifier_pattern) @parameter
-(list_pattern (identifier) @parameter)
-(spread_pattern (identifier) @parameter)
+(list_pattern (value_identifier) @parameter)
+(spread_pattern (value_identifier) @parameter)
 
 ; String literals
 ;----------------
@@ -62,12 +62,12 @@
 ;----------
 
 [
- (formal_parameters (identifier))
- (positional_parameter (identifier))
- (labeled_parameter (identifier))
+ (formal_parameters (value_identifier))
+ (positional_parameter (value_identifier))
+ (labeled_parameter (value_identifier))
 ] @parameter
 
-(function parameter: (identifier) @parameter)
+(function parameter: (value_identifier) @parameter)
 
 ; Meta
 ;-----

--- a/test/corpus/error_scopes.txt
+++ b/test/corpus/error_scopes.txt
@@ -14,7 +14,7 @@ let x = 5
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match (number) (expression_statement (number)))
-      (ERROR (identifier) (UNEXPECTED 'p'))))
-  (let_binding (identifier) (number)))
+      (ERROR (value_identifier) (UNEXPECTED 'p'))))
+  (let_binding (value_identifier) (number)))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -33,14 +33,14 @@ Foo.Bar.baz.qux
 
 (source_file
   (expression_statement
-    (module_nested_identifier
-      (module_name)
-      (module_name) (identifier)))
+    (value_identifier_path
+      (module_identifier)
+      (module_identifier) (value_identifier)))
   (expression_statement
     (member_expression
-      (module_nested_identifier
-        (module_name)
-        (module_name) (identifier))
+      (value_identifier_path
+        (module_identifier)
+        (module_identifier) (value_identifier))
       (property_identifier))))
 
 ===========================================
@@ -51,7 +51,7 @@ Escape identifiers
 
 ---
 
-(source_file (expression_statement (identifier)))
+(source_file (expression_statement (value_identifier)))
 
 ===========================================
 Tuple
@@ -86,44 +86,44 @@ keep(
 (source_file
   (expression_statement
     (call_expression
-      function: (identifier)
+      function: (value_identifier)
       arguments: (arguments (number) (number))))
   (expression_statement
     (call_expression
-      function: (identifier)
+      function: (value_identifier)
       arguments: (arguments
         (number)
         (labeled_argument
-          label: (identifier)
+          label: (value_identifier)
           value: (number))
         (labeled_argument
-          label: (identifier))
+          label: (value_identifier))
         (unit))))
   (expression_statement
     (call_expression
-      function: (identifier)
+      function: (value_identifier)
       arguments: (arguments
         (labeled_argument
-          label: (identifier))
+          label: (value_identifier))
         (labeled_argument
-          label: (identifier)
-          value: (identifier)))))
+          label: (value_identifier)
+          value: (value_identifier)))))
   (expression_statement
     (call_expression
-      function: (identifier)
+      function: (value_identifier)
       arguments: (arguments (uncurry) (number))))
   (expression_statement
     (call_expression
-      function: (identifier)
+      function: (value_identifier)
       arguments: (arguments
         (function
-          parameter: (identifier)
+          parameter: (value_identifier)
           body: (binary_expression
             left: (pipe_expression
-              (identifier)
-              (module_nested_identifier
-                (module_name)
-                (identifier)))
+              (value_identifier)
+              (value_identifier_path
+                (module_identifier)
+                (value_identifier)))
             right: (number)))))))
 
 ===========================================
@@ -143,28 +143,28 @@ bbox
 (source_file
  (expression_statement
     (pipe_expression
-      (pipe_expression (identifier) (identifier))
-      (identifier)))
+      (pipe_expression (value_identifier) (value_identifier))
+      (value_identifier)))
  (expression_statement
     (pipe_expression
-      (pipe_expression (identifier) (identifier))
-      (identifier)))
+      (pipe_expression (value_identifier) (value_identifier))
+      (value_identifier)))
   (expression_statement
     (pipe_expression
       (call_expression
         (pipe_expression
-          (identifier)
-          (module_nested_identifier (module_name) (identifier)))
-        (arguments (identifier)))
-      (module_nested_identifier (module_name) (identifier))))
+          (value_identifier)
+          (value_identifier_path (module_identifier) (value_identifier)))
+        (arguments (value_identifier)))
+      (value_identifier_path (module_identifier) (value_identifier))))
   (expression_statement
     (pipe_expression
       (number)
       (variant_identifier)))
   (expression_statement
     (pipe_expression
-      (identifier)
-      (identifier))))
+      (value_identifier)
+      (value_identifier))))
 
 ===========================================
 Record
@@ -184,7 +184,7 @@ Record
 (source_file
   (expression_statement
     (record
-      (spread_element (identifier))
+      (spread_element (value_identifier))
       (record_field (property_identifier) (number))
       (record_field (property_identifier) (string (string_fragment)))
       (record_field (property_identifier))))
@@ -257,24 +257,24 @@ if predicateA {
 (source_file
   (expression_statement
     (if_expression
-      (identifier)
-      (block (expression_statement (identifier)))))
+      (value_identifier)
+      (block (expression_statement (value_identifier)))))
   (expression_statement
     (if_expression
-      (identifier)
-      (block (expression_statement (identifier)))
-      (else_clause (block (expression_statement (identifier))))))
+      (value_identifier)
+      (block (expression_statement (value_identifier)))
+      (else_clause (block (expression_statement (value_identifier))))))
   (expression_statement
     (if_expression
-      (identifier)
-      (block (expression_statement (identifier)))
+      (value_identifier)
+      (block (expression_statement (value_identifier)))
       (else_if_clause
-        (identifier)
-        (block (expression_statement (identifier))))
+        (value_identifier)
+        (block (expression_statement (value_identifier))))
       (else_if_clause
-        (identifier)
-        (block (expression_statement (identifier))))
-      (else_clause (block (expression_statement (identifier)))))))
+        (value_identifier)
+        (block (expression_statement (value_identifier))))
+      (else_clause (block (expression_statement (value_identifier)))))))
 
 ===========================================
 Switch of literals
@@ -292,17 +292,17 @@ switch foo {
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match
         (number)
         (number)
         (expression_statement (string (string_fragment))))
       (switch_match
-        (identifier)
-        (let_binding (identifier) (string (string_fragment)))
+        (value_identifier)
+        (let_binding (value_identifier) (string (string_fragment)))
         (expression_statement
           (binary_expression
-            (identifier)
+            (value_identifier)
             (string (string_fragment))))))))
 
 ===========================================
@@ -319,22 +319,22 @@ switch foo {
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match
         (variant_pattern
           (variant_identifier)
           (formal_parameters
-            (identifier)
-            (as_aliasing (identifier))
+            (value_identifier)
+            (as_aliasing (value_identifier))
             (type_annotation (type_identifier))
             (record_pattern
               (shorthand_property_identifier_pattern)
               (shorthand_property_identifier_pattern))))
-        (expression_statement (identifier)))
+        (expression_statement (value_identifier)))
       (switch_match
         (variant_pattern
           (nested_variant_identifier
-            (module_name)
+            (module_identifier)
             (variant_identifier)))
         (expression_statement (number))))))
 
@@ -352,7 +352,7 @@ switch foo {
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match
         (polyvar_pattern (polyvar_identifier))
         (expression_statement (number)))
@@ -360,11 +360,11 @@ switch foo {
         (polyvar_pattern
           (polyvar_identifier)
           (formal_parameters
-            (identifier)
-            (as_aliasing (identifier))
+            (value_identifier)
+            (as_aliasing (value_identifier))
             (type_annotation (type_identifier))
             (number)))
-        (as_aliasing (identifier))
+        (as_aliasing (value_identifier))
         (expression_statement (number))))))
 
 ===========================================
@@ -381,16 +381,16 @@ switch foo {
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match
-        (identifier)
+        (value_identifier)
         (switch_pattern_condition
           (binary_expression
-            (binary_expression (identifier) (number))
-            (binary_expression (identifier) (number))))
-        (expression_statement (identifier)))
+            (binary_expression (value_identifier) (number))
+            (binary_expression (value_identifier) (number))))
+        (expression_statement (value_identifier)))
       (switch_match
-        (identifier)
+        (value_identifier)
         (expression_statement (number))))))
 
 ===========================================
@@ -407,15 +407,15 @@ switch (foo, bar) {
 (source_file
   (expression_statement
     (switch_expression
-      (tuple (identifier) (identifier))
+      (tuple (value_identifier) (value_identifier))
       (switch_match
         (tuple
           (number)
           (number)
-          (as_aliasing (identifier)))
+          (as_aliasing (value_identifier)))
         (expression_statement (number)))
       (switch_match
-        (tuple_pattern (identifier) (identifier))
+        (tuple_pattern (value_identifier) (value_identifier))
         (expression_statement (number))))))
 
 ===========================================
@@ -434,21 +434,21 @@ switch foo {
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match
         (list_pattern
-          (identifier)
-          (as_aliasing (identifier))
-          (spread_pattern (identifier)))
+          (value_identifier)
+          (as_aliasing (value_identifier))
+          (spread_pattern (value_identifier)))
         (expression_statement (number)))
       (switch_match
-        (list_pattern (number) (number) (identifier))
+        (list_pattern (number) (number) (value_identifier))
         (expression_statement (number)))
       (switch_match
         (list_pattern (number))
         (expression_statement (number)))
       (switch_match
-        (list_pattern (spread_pattern (identifier)))
+        (list_pattern (spread_pattern (value_identifier)))
         (expression_statement (number))))))
 
 ===========================================
@@ -468,22 +468,22 @@ switch foo {
 (source_file
   (expression_statement
     (switch_expression
-      (identifier)
+      (value_identifier)
       (switch_match
-        (array_pattern (identifier) (spread_pattern (identifier)))
+        (array_pattern (value_identifier) (spread_pattern (value_identifier)))
         (expression_statement (number)))
       (switch_match
         (array_pattern
           (number)
           (number)
-          (as_aliasing (identifier))
-          (identifier))
+          (as_aliasing (value_identifier))
+          (value_identifier))
         (expression_statement (number)))
       (switch_match
         (array_pattern (number))
         (expression_statement (number)))
       (switch_match
-        (array_pattern (spread_pattern (identifier)))
+        (array_pattern (spread_pattern (value_identifier)))
         (expression_statement (number))))))
 
 ===========================================
@@ -500,13 +500,13 @@ switch parseExn(str) {
 (source_file
   (expression_statement
     (switch_expression
-      (call_expression (identifier) (arguments (identifier)))
-      (switch_match (identifier) (expression_statement (number)))
+      (call_expression (value_identifier) (arguments (value_identifier)))
+      (switch_match (value_identifier) (expression_statement (number)))
       (switch_match
         (exception
           (variant_pattern
-            (nested_variant_identifier (module_name) (module_name) (variant_identifier))
-            (formal_parameters (identifier))))
+            (nested_variant_identifier (module_identifier) (module_identifier) (variant_identifier))
+            (formal_parameters (value_identifier))))
         (expression_statement (number))))))
 
 ===========================================
@@ -541,15 +541,15 @@ i && j;
 ---
 
 (source_file
-  (expression_statement (binary_expression (identifier) (identifier)))
-  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (value_identifier) (value_identifier)))
+  (expression_statement (binary_expression (value_identifier) (value_identifier)))
   (expression_statement (binary_expression
     (binary_expression
-      (unary_expression (identifier))
-      (unary_expression (identifier)))
+      (unary_expression (value_identifier))
+      (unary_expression (value_identifier)))
     (binary_expression
-      (unary_expression (identifier))
-      (unary_expression (identifier))))))
+      (unary_expression (value_identifier))
+      (unary_expression (value_identifier))))))
 
 ============================================
 String operators
@@ -561,10 +561,10 @@ s1 ++ s2 ++ s3
 ---
 
 (source_file
-  (expression_statement (binary_expression (identifier) (identifier)))
+  (expression_statement (binary_expression (value_identifier) (value_identifier)))
   (expression_statement (binary_expression
-    (binary_expression (identifier) (identifier))
-    (identifier))))
+    (binary_expression (value_identifier) (value_identifier))
+    (value_identifier))))
 
 ==============================================
 Ternaries
@@ -580,9 +580,9 @@ condition
 
 (source_file
   (expression_statement (ternary_expression
-    (identifier) (identifier) (identifier)))
+    (value_identifier) (value_identifier) (value_identifier)))
   (expression_statement (ternary_expression
-    (identifier) (identifier) (identifier))))
+    (value_identifier) (value_identifier) (value_identifier))))
 
 ============================================
 Arrays
@@ -627,8 +627,8 @@ list{ ...xs, 1, 2 }
   (expression_statement (list (number)))
   (expression_statement (list (number)))
   (expression_statement (list (number) (number)))
-  (expression_statement (list (number) (number) (spread_element (identifier))))
-  (expression_statement (list (spread_element (identifier)) (number) (number))))
+  (expression_statement (list (number) (number) (spread_element (value_identifier))))
+  (expression_statement (list (spread_element (value_identifier)) (number) (number))))
 
 ============================================
 Subscript expressions
@@ -640,9 +640,9 @@ myObj["foo"]
 ---
 
 (source_file
-  (expression_statement (subscript_expression (identifier) (number)))
+  (expression_statement (subscript_expression (value_identifier) (number)))
   (expression_statement
-    (subscript_expression (identifier) (string (string_fragment)))))
+    (subscript_expression (value_identifier) (string (string_fragment)))))
 
 ============================================
 Variants
@@ -661,7 +661,7 @@ Foo(qux, { bar: 3 }, )
     (variant
       (variant_identifier)
       (arguments
-        (identifier)
+        (value_identifier)
         (record (record_field (property_identifier) (number)))))))
 
 ============================================

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -17,34 +17,34 @@ a => 1
 
 (source_file
   (expression_statement (function
-    (identifier)
+    (value_identifier)
     (number)))
   (expression_statement (function
     (formal_parameters)
     (number)))
   (expression_statement (function
-    (formal_parameters (identifier) (identifier))
+    (formal_parameters (value_identifier) (value_identifier))
     (number)))
   (expression_statement (function
-    (formal_parameters (identifier) (identifier))
+    (formal_parameters (value_identifier) (value_identifier))
     (block
-      (expression_statement (identifier)))))
+      (expression_statement (value_identifier)))))
   (expression_statement (function
-    (formal_parameters (identifier))
+    (formal_parameters (value_identifier))
     (number)))
   (expression_statement (function
-    (formal_parameters (identifier) (identifier))
+    (formal_parameters (value_identifier) (value_identifier))
     (number)))
   (expression_statement (function
-    (formal_parameters (identifier) (identifier)) (number)))
+    (formal_parameters (value_identifier) (value_identifier)) (number)))
   (expression_statement (function
     (formal_parameters
-      (identifier)
+      (value_identifier)
       (uncurry)
-      (identifier)
-      (identifier)
+      (value_identifier)
+      (value_identifier)
       (uncurry)
-      (identifier))
+      (value_identifier))
     (number))))
 
 ===================================================
@@ -59,8 +59,8 @@ Type annotations
   (expression_statement
     (function
       parameters: (formal_parameters
-        (positional_parameter (identifier) (type_annotation (type_identifier)))
-        (labeled_parameter (identifier) (type_annotation (type_identifier))))
+        (positional_parameter (value_identifier) (type_annotation (type_identifier)))
+        (labeled_parameter (value_identifier) (type_annotation (type_identifier))))
       return_type: (type_annotation (type_identifier))
       body: (number))))
 
@@ -77,17 +77,17 @@ Parameter defaults
     (function
       parameters: (formal_parameters
         (labeled_parameter
-          (identifier)
+          (value_identifier)
           (type_annotation (type_identifier))
           default_value: (number))
         (labeled_parameter
-          (identifier)
+          (value_identifier)
           default_value: (number))
         (labeled_parameter
-          (identifier)
+          (value_identifier)
           (type_annotation (type_identifier)))
         (labeled_parameter
-          (identifier))
+          (value_identifier))
         (unit))
       body: (number))))
 
@@ -104,8 +104,8 @@ Parameter aliasing
     (function
       (formal_parameters
         (labeled_parameter
-          (identifier)
-          (as_aliasing (identifier))
+          (value_identifier)
+          (as_aliasing (value_identifier))
           (type_annotation (type_identifier))
           (number)))
       (number))))
@@ -128,7 +128,7 @@ Record pattern
           (shorthand_property_identifier_pattern)
           (shorthand_property_identifier_pattern))
         (shorthand_property_identifier_pattern)
-        (identifier)))
+        (value_identifier)))
     (number))))
 
 ===================================================
@@ -141,9 +141,9 @@ Operator precendence
 
 (source_file
   (expression_statement (function
-    (formal_parameters (identifier))
+    (formal_parameters (value_identifier))
     (binary_expression
       (pipe_expression
-        (identifier)
-        (module_nested_identifier (module_name) (identifier)))
+        (value_identifier)
+        (value_identifier_path (module_identifier) (value_identifier)))
       (number)))))

--- a/test/corpus/jsx.txt
+++ b/test/corpus/jsx.txt
@@ -17,12 +17,12 @@ Simple JSX elements
   (expression_statement
     (jsx_element
       (jsx_opening_element (nested_jsx_identifier (jsx_identifier) (jsx_identifier)))
-      (identifier)
+      (value_identifier)
       (jsx_element
         (jsx_opening_element (jsx_identifier))
-        (identifier)
+        (value_identifier)
         (jsx_closing_element (jsx_identifier)))
-      (identifier)
+      (value_identifier)
       (jsx_closing_element (nested_jsx_identifier (jsx_identifier) (jsx_identifier)))))
   (expression_statement
     (jsx_element
@@ -59,13 +59,13 @@ Attribute values
       (jsx_attribute (property_identifier) (variant (variant_identifier)))
       (jsx_attribute (property_identifier))
       (jsx_attribute (property_identifier))
-      (jsx_attribute (property_identifier) (jsx_expression (identifier)))))
+      (jsx_attribute (property_identifier) (jsx_expression (value_identifier)))))
   (expression_statement
     (jsx_self_closing_element
       (jsx_identifier)
       (jsx_attribute
         (property_identifier)
-        (pipe_expression (identifier) (identifier)))
+        (pipe_expression (value_identifier) (value_identifier)))
       (jsx_attribute
         (property_identifier)
         (true)))))

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -10,10 +10,10 @@ export d = 5
 ---
 
 (source_file
-  (let_binding (identifier) (number))
-  (let_binding (identifier) (identifier))
-  (let_binding (identifier) (polyvar (polyvar_identifier)))
-  (let_binding (identifier) (number)))
+  (let_binding (value_identifier) (number))
+  (let_binding (value_identifier) (value_identifier))
+  (let_binding (value_identifier) (polyvar (polyvar_identifier)))
+  (let_binding (value_identifier) (number)))
 
 ============================================
 Tuple destructuring
@@ -26,10 +26,10 @@ let (a, b, (c, d)) = foo
 (source_file
   (let_binding
     (tuple_pattern
-      (identifier)
-      (identifier)
-      (tuple_pattern (identifier) (identifier)))
-    (identifier)))
+      (value_identifier)
+      (value_identifier)
+      (tuple_pattern (value_identifier) (value_identifier)))
+    (value_identifier)))
 
 ============================================
 Block
@@ -44,7 +44,7 @@ let x = {
 
 (source_file
   (let_binding
-    (identifier)
+    (value_identifier)
     (block
       (expression_statement (number))
       (expression_statement (number)))))
@@ -60,16 +60,16 @@ let b: 'a => unit = ignore
 
 (source_file
   (let_binding
-    (identifier)
+    (value_identifier)
     (type_annotation (type_identifier))
     (number))
   (let_binding
-    (identifier)
+    (value_identifier)
     (type_annotation
       (function_type
         (function_type_parameters (type_identifier))
         (unit_type)))
-    (identifier)))
+    (value_identifier)))
 
 ============================================
 Recursive
@@ -81,12 +81,12 @@ let rec foo = n => foo(n-1)
 
 (source_file
   (let_binding
-    (identifier)
+    (value_identifier)
       (function
-        (identifier)
+        (value_identifier)
         (call_expression
-          (identifier)
+          (value_identifier)
           (arguments
             (binary_expression
-              (identifier)
+              (value_identifier)
               (number)))))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -115,10 +115,10 @@ The caller should either handle this error, or expect that exit code.`
   (expression_statement (template_string
     (escape_sequence)
     (template_substitution (call_expression
-      (identifier)
+      (value_identifier)
       (arguments (string (string_fragment)))))
     (escape_sequence)
-    (template_substitution (identifier))))
+    (template_substitution (value_identifier))))
   (expression_statement (template_string))
   (expression_statement (template_string (escape_sequence))))
 

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -8,9 +8,9 @@ open! Foo.Bar
 ---
 
 (source_file
-  (open_statement (module_name))
+  (open_statement (module_identifier))
   (open_statement
-    (nested_module_expression (module_name) (module_name))))
+    (module_identifier_path (module_identifier) (module_identifier))))
 
 ===========================================
 Include
@@ -23,12 +23,12 @@ include module type of Belt.Array
 ---
 
 (source_file
-  (include_statement (module_name))
+  (include_statement (module_identifier))
   (include_statement
-    (nested_module_expression (module_name) (module_name)))
+    (module_identifier_path (module_identifier) (module_identifier)))
   (include_statement
     (module_type_of
-      (nested_module_expression (module_name) (module_name)))))
+      (module_identifier_path (module_identifier) (module_identifier)))))
 
 ===========================================
 Simple definition
@@ -42,7 +42,7 @@ module MyModule = {
 
 (source_file
   (module_declaration
-    (module_name)
+    (module_identifier)
     (block (type_declaration (type_identifier)))))
 
 ===========================================
@@ -69,17 +69,17 @@ module MyModule: {
 
 (source_file
   (module_declaration
-    (module_name)
+    (module_identifier)
     signature: (block
-      (let_binding (identifier) (type_annotation (type_identifier)))
-      (let_binding (identifier) (type_annotation (type_identifier)))
-      (let_binding (identifier) (type_annotation (type_identifier)))))
+      (let_binding (value_identifier) (type_annotation (type_identifier)))
+      (let_binding (value_identifier) (type_annotation (type_identifier)))
+      (let_binding (value_identifier) (type_annotation (type_identifier)))))
   (module_declaration
-    (module_name)
-    signature: (nested_module_expression (module_name) (module_name))
+    (module_identifier)
+    signature: (module_identifier_path (module_identifier) (module_identifier))
     definition: (block (type_declaration (type_identifier))))
   (module_declaration
-    (module_name)
+    (module_identifier)
     signature: (block (type_declaration (type_identifier)))
     definition: (block (type_declaration (type_identifier) (type_identifier)))))
 
@@ -93,10 +93,10 @@ module Q = Foo.Bar.Qux
 
 (source_file
   (module_declaration
-    (module_name)
-    (nested_module_expression
-      (nested_module_expression (module_name) (module_name))
-      (module_name))))
+    (module_identifier)
+    (module_identifier_path
+      (module_identifier_path (module_identifier) (module_identifier))
+      (module_identifier))))
 
 ===========================================
 Externals
@@ -112,7 +112,7 @@ external _makeStyles: ({..}, . unit) => {..} = "makeStyles"
 
 (source_file
   (external_declaration
-    (identifier)
+    (value_identifier)
     (type_annotation
       (function_type
         (function_type_parameters (type_identifier))
@@ -121,13 +121,13 @@ external _makeStyles: ({..}, . unit) => {..} = "makeStyles"
   (decorated
     (decorator (decorator_identifier))
     (external_declaration
-      (identifier)
+      (value_identifier)
       (type_annotation (type_identifier))
       (string (string_fragment))))
   (decorated
     (decorator (decorator_identifier))
     (external_declaration
-      (identifier)
+      (value_identifier)
       (type_annotation (type_identifier))
       (string (string_fragment))))
   (decorated
@@ -136,11 +136,11 @@ external _makeStyles: ({..}, . unit) => {..} = "makeStyles"
       (decorator_arguments (string (string_fragment))))
     (decorator (decorator_identifier))
     (external_declaration
-      (identifier)
+      (value_identifier)
       (type_annotation (type_identifier))
       (string (string_fragment))))
   (external_declaration
-    (identifier)
+    (value_identifier)
     (type_annotation
       (function_type
         (function_type_parameters

--- a/test/corpus/mutation_statements.txt
+++ b/test/corpus/mutation_statements.txt
@@ -10,11 +10,11 @@ foo.bar := qux
 
 (source_file
   (mutation_statement
-    (subscript_expression (identifier) (string (string_fragment)))
-    (identifier))
+    (subscript_expression (value_identifier) (string (string_fragment)))
+    (value_identifier))
   (mutation_statement
-    (member_expression (identifier) (property_identifier))
-    (identifier))
+    (member_expression (value_identifier) (property_identifier))
+    (value_identifier))
   (mutation_statement
-    (member_expression (identifier) (property_identifier))
-    (identifier)))
+    (member_expression (value_identifier) (property_identifier))
+    (value_identifier)))

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -32,8 +32,8 @@ type t = Foo.Bar.qux
 (source_file
   (type_declaration
     (type_identifier)
-    (nested_type_identifier
-      (module_name) (module_name) (type_identifier))))
+    (type_identifier_path
+      (module_identifier) (module_identifier) (type_identifier))))
 
 ===========================================
 Tuple type
@@ -179,10 +179,10 @@ type fooD = (~arg1: t1, ~arg2: t2=?, unit) => float
     (function_type
       (function_type_parameters
         (labeled_parameter
-          (identifier)
+          (value_identifier)
           (type_annotation (type_identifier)))
         (labeled_parameter
-          (identifier)
+          (value_identifier)
           (type_annotation (type_identifier)))
         (unit_type))
       (type_identifier))))


### PR DESCRIPTION
- simple `identifier` -> `value_identifier`
- `module_name` -> `module_identifier`
- `nested_*` -> `*_path`