### PR TITLE
Relax decorator arg constrains

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -837,11 +837,15 @@ module.exports = grammar({
       $.subscript_expression,
     ),
 
-    decorator: $ => seq('@', $.decorator_identifier, optional($.decorator_arguments)),
+    decorator: $ => seq(
+      '@',
+      $.decorator_identifier,
+      optional($.decorator_arguments)
+    ),
 
     decorator_arguments: $ => seq(
       '(',
-      commaSep($.string),
+      commaSep($.expression),
       ')',
     ),
 

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -244,3 +244,24 @@ type rec t = t
 
 (source_file
   (type_declaration (type_identifier) (type_identifier)))
+
+===========================================
+Decorated
+===========================================
+
+@deriving(abstract)
+type transitionCreateArgs = {
+  easing: string,
+}
+
+---
+
+(source_file
+  (decorated
+    (decorator (decorator_identifier) (decorator_arguments (value_identifier)))
+    (type_declaration
+      (type_identifier)
+      (record_type
+        (record_type_field
+          (property_identifier)
+          (type_annotation (type_identifier)))))))


### PR DESCRIPTION
Allow `@deriving(abstract)` for example