### PR TITLE
Bring rescript-material-ui to wild test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ TS=yarn tree-sitter
 # for acceptance testing. The general idea: if `tree-sitter-rescript`
 # is 100% legit for this codebase, it should satisfy everyone.
 wild_github_repos := rescript-lang/rescript-react \
-										 tinymce/rescript-webapi
+										 tinymce/rescript-webapi \
+										 cca-io/rescript-material-ui
 
 wild_sandboxes := $(patsubst %,test_wild/%,$(wild_github_repos))
 

--- a/grammar.js
+++ b/grammar.js
@@ -164,6 +164,7 @@ module.exports = grammar({
       $.block,
       $.module_expression,
       $.functor,
+      $.extension_expression,
     ),
 
     functor: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -804,6 +804,10 @@ module.exports = grammar({
     _jsx_child: $ => choice(
       $.value_identifier,
       $.value_identifier_path,
+      $.number,
+      $.string,
+      $.template_string,
+      $.character,
       $._jsx_element,
       $.jsx_fragment,
       $.jsx_expression

--- a/test/corpus/jsx.txt
+++ b/test/corpus/jsx.txt
@@ -46,6 +46,27 @@ Simple JSX elements
       (jsx_closing_element (jsx_identifier)))))
 
 ==============================================
+Custom type children
+==============================================
+
+<div> "Hello" </div>
+<div> 48 </div>
+
+---
+
+(source_file
+  (expression_statement
+    (jsx_element
+      (jsx_opening_element (jsx_identifier))
+      (string (string_fragment))
+      (jsx_closing_element (jsx_identifier))))
+  (expression_statement
+    (jsx_element
+      (jsx_opening_element (jsx_identifier))
+      (number)
+      (jsx_closing_element (jsx_identifier)))))
+
+==============================================
 Attribute values
 ==============================================
 <Foo a=1 b=#hello c=None punned ?optA optB=?{foo} />;

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -194,6 +194,21 @@ module rec BYOBReader: {
     (module_identifier)))
 
 ===========================================
+Definition through extension
+===========================================
+
+module Styles = %makeStyles(())
+
+---
+
+(source_file
+  (module_declaration
+    (module_identifier)
+    (extension_expression
+      (extension_identifier)
+      (expression_statement (unit)))))
+
+===========================================
 Externals
 ===========================================
 


### PR DESCRIPTION
- Allow `module Foo = %extension()`
- Allow plain literals as JSX children: `<Foo> 42 </Foo>`