### PR TITLE
feat: add queries for nvim-treesitter-textobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a parser definition of the [ReScript](https://rescript-
 
 Athough Tree-sitter has many applications, the main intent of this parser is powering the [`nvim-treesitter-rescript`](https://github.com/nkrkv/nvim-tree-sitter-rescript/) NeoVim plugin which may be used to improve development experience in the NeoVim + ReScript combo.
 
+Queries for text objects are also included which help you to navigate, select, and modify ReScript code syntactically. For NeoVim, the [`nvim-treesitter-textobjects`](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) plugin is required to use Tree-sitter text objects.
+
 ## Installation
 
 - If you want ReScript Tree-sitter in NeoVim, refer to [`nvim-treesitter-rescript`](https://github.com/nkrkv/nvim-tree-sitter-rescript/) installation notes;

--- a/queries/textobjects.scm
+++ b/queries/textobjects.scm
@@ -1,0 +1,114 @@
+; Queries for nvim-treesitter/nvim-treesitter-textobjects
+;--------------------------------------------------------
+
+; Classes (modules)
+;------------------
+
+(module_declaration definition: ((_) @class.inner)) @class.outer
+
+; Blocks
+;-------
+
+(block (_) @block.inner) @block.outer
+
+; Functions
+;----------
+
+(function body: (_) @function.inner) @function.outer
+
+; Calls
+;------
+
+(call_expression arguments: ((_) @call.inner)) @call.outer
+
+; Comments
+;---------
+
+(comment) @comment.outer
+
+; Parameters
+;-----------
+
+(function parameter: (_) @parameter.inner @parameter.outer)
+
+(formal_parameters
+  "," @_formal_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_formal_parameters_start @parameter.inner))
+(formal_parameters
+  . (_) @parameter.inner
+  . ","? @_formal_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_formal_parameters_end))
+
+(arguments
+  "," @_arguments_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_arguments_start @parameter.inner))
+(arguments
+  . (_) @parameter.inner
+  . ","? @_arguments_end
+  (#make-range! "parameter.outer" @parameter.inner @_arguments_end))
+
+(function_type_parameters
+  "," @_function_type_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_function_type_parameters_start @parameter.inner))
+(function_type_parameters
+  . (_) @parameter.inner
+  . ","? @_function_type_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_function_type_parameters_end))
+
+(functor_parameters
+  "," @_functor_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_functor_parameters_start @parameter.inner))
+(functor_parameters
+  . (_) @parameter.inner
+  . ","? @_functor_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_functor_parameters_end))
+
+(type_parameters
+  "," @_type_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_type_parameters_start @parameter.inner))
+(type_parameters
+  . (_) @parameter.inner
+  . ","? @_type_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_type_parameters_end))
+
+(type_arguments
+  "," @_type_arguments_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_type_arguments_start @parameter.inner))
+(type_arguments
+  . (_) @parameter.inner
+  . ","? @_type_arguments_end
+  (#make-range! "parameter.outer" @parameter.inner @_type_arguments_end))
+
+(decorator_arguments
+  "," @_decorator_arguments_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_decorator_arguments_start @parameter.inner))
+(decorator_arguments
+  . (_) @parameter.inner
+  . ","? @_arguments_end
+  (#make-range! "parameter.outer" @parameter.inner @_arguments_end))
+
+(variant_parameters
+  "," @_variant_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_variant_parameters_start @parameter.inner))
+(variant_parameters
+  . (_) @parameter.inner
+  . ","? @_variant_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_variant_parameters_end))
+
+(polyvar_parameters
+  "," @_polyvar_parameters_start
+  . (_) @parameter.inner
+  (#make-range! "parameter.outer" @_polyvar_parameters_start @parameter.inner))
+(polyvar_parameters
+  . (_) @parameter.inner
+  . ","? @_polyvar_parameters_end
+  (#make-range! "parameter.outer" @parameter.inner @_polyvar_parameters_end))
+


### PR DESCRIPTION
Adds queries for the [`nvim-treesitter/nvim-treesitter-textobjects`](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) plugin, enabling users to navigate, select, and modify ReScript code using text objects. See [nvim-treesitter-textobjects/CONTRIBUTING.md](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/master/CONTRIBUTING.md) for more info.

Notes:

- I had trouble writing a query to select uncurried function parameters so they currently aren't handled properly. Suggestions are welcome 😅

- I had included a sentence in the README mentioning this feature in the previous PR, but I left it out of this one because this repo isn’t directly targeted towards nvim. Do you think it should be included, either here or in the nvim repo?

Previous PR: https://github.com/nkrkv/nvim-treesitter-rescript/pull/5