### PR TITLE
A few more things

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -227,10 +227,10 @@ module.exports = grammar({
         '=',
         optional('private'),
         $._type,
-      )),
-      optional(seq(
-        'and',
-        $._type_declaration
+        optional(seq(
+          token('and'),
+          $._type_declaration
+        )),
       )),
     ),
 
@@ -381,11 +381,19 @@ module.exports = grammar({
     let_binding: $ => seq(
       choice('export', 'let'),
       optional('rec'),
+      $._let_binding,
+    ),
+
+    _let_binding: $ => seq(
       choice($._pattern, $.unit),
       optional($.type_annotation),
       optional(seq(
         '=',
         $.expression,
+        optional(seq(
+          token('and'),
+          $._let_binding,
+        )),
       )),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -992,6 +992,7 @@ module.exports = grammar({
       repeat1('%'),
       choice(
         $._raw_js_extension,
+        $._raw_gql_extension,
         $._simple_extension,
       ),
     )),
@@ -1024,6 +1025,32 @@ module.exports = grammar({
           $.escape_sequence,
         ),
       )), $.raw_js),
+      '`',
+    ),
+
+    _raw_gql_extension: $ => seq(
+      alias(token('graphql'), $.extension_identifier),
+      '(',
+      alias($._raw_gql, $.expression_statement),
+      ')',
+    ),
+
+    _raw_gql: $ => choice(
+      alias($._raw_gql_template_string, $.template_string),
+      alias($._raw_gql_string, $.string),
+    ),
+
+    _raw_gql_string: $ => alias($.string, $.raw_gql),
+
+    _raw_gql_template_string: $ => seq(
+      '`',
+      alias(repeat(choice(
+        $._template_chars,
+        choice(
+          alias('\\`', $.escape_sequence),
+          $.escape_sequence,
+        ),
+      )), $.raw_gql),
       '`',
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -370,6 +370,7 @@ module.exports = grammar({
     ),
 
     function_type_parameter: $ => seq(
+      optional($.uncurry),
       repeat($.decorator),
       choice(
         $._type,
@@ -813,7 +814,7 @@ module.exports = grammar({
     jsx_expression: $ => seq(
       '{',
       optional(choice(
-        $.expression,
+        $._one_or_more_statements,
         $.spread_element
       )),
       '}'
@@ -881,7 +882,7 @@ module.exports = grammar({
         $._jsx_attribute_value
       )),
     ),
-
+    
     _jsx_attribute_value: $ => choice(
       $.primary_expression,
       $.jsx_expression,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -101,6 +101,7 @@
   "private"
   "rec"
   "type"
+  "and"
 ] @keyword
 
 [

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,5 @@
+((raw_js) @injection.content
+ (#set! injection.language "javascript"))
+
+((raw_gql) @injection.content
+ (#set! injection.language "graphql"))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -908,6 +908,13 @@ let x = %raw(`
     return "\" + a + "\";
   }
 `)
+module Test = %graphql(`
+  query {
+    test {
+      id
+    }
+  }
+`)
 
 ---
 
@@ -958,7 +965,14 @@ let x = %raw(`
             (template_string
               (raw_js
                 (escape_sequence)
-                (escape_sequence)))))))
+                (escape_sequence))))))
+  (module_declaration
+    name: (module_identifier)
+    definition: (extension_expression
+      (extension_identifier)
+      (expression_statement
+        (template_string
+          (raw_gql))))))
 
 ===========================================
 Raise expression

--- a/test/corpus/jsx.txt
+++ b/test/corpus/jsx.txt
@@ -14,7 +14,7 @@ Simple JSX elements
     (jsx_self_closing_element
       (jsx_identifier)
       (jsx_attribute (property_identifier) (string (string_fragment)))
-      (jsx_attribute (property_identifier) (jsx_expression (number)))))
+      (jsx_attribute (property_identifier) (jsx_expression (expression_statement (number))))))
   (expression_statement
     (jsx_element
       (jsx_opening_element (nested_jsx_identifier (jsx_identifier) (jsx_identifier)))
@@ -86,7 +86,7 @@ Attribute values
       (jsx_attribute (property_identifier) (variant (variant_identifier)))
       (jsx_attribute (property_identifier))
       (jsx_attribute (property_identifier))
-      (jsx_attribute (property_identifier) (jsx_expression (value_identifier)))))
+      (jsx_attribute (property_identifier) (jsx_expression (expression_statement (value_identifier))))))
   (expression_statement
     (jsx_self_closing_element
       (jsx_identifier)
@@ -158,3 +158,55 @@ Children spread
       (jsx_opening_element (jsx_identifier))
       (spread_element (value_identifier))
       (jsx_closing_element (jsx_identifier)))))
+
+===================================================
+Attribute Block
+===================================================
+
+<SingleInput
+  header={React.string("What's your first name?")}
+  event={
+    open SingleInput
+    {
+      submit: toNextStep,
+      isLoading: false,
+    }
+  }>
+    <Input />
+</SingleInput>
+
+---
+
+(source_file
+  (expression_statement
+    (jsx_element
+      (jsx_opening_element
+        (jsx_identifier)
+        (jsx_attribute
+          (property_identifier)
+          (jsx_expression
+            (expression_statement
+              (call_expression
+                (value_identifier_path
+                  (module_identifier)
+                  (value_identifier))
+                (arguments
+                  (string
+                    (string_fragment)))))))
+        (jsx_attribute
+          (property_identifier)
+          (jsx_expression
+            (open_statement
+              (module_identifier))
+            (expression_statement
+              (record
+                (record_field
+                  (property_identifier)
+                  (value_identifier))
+                (record_field
+                  (property_identifier)
+                  (false)))))))
+      (jsx_self_closing_element
+        (jsx_identifier))
+      (jsx_closing_element
+        (jsx_identifier)))))

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -144,3 +144,21 @@ let rec a = x => x + b(x) and b = y => y - 1
       (binary_expression
         (value_identifier)
         (number)))))   
+    
+===========================================
+Labled function with uncurried
+===========================================
+      
+let test = (. ~attr) => ()
+
+---
+
+(source_file
+  (let_binding
+    (value_identifier)
+    (function
+      (formal_parameters
+        (uncurry)
+        (labeled_parameter
+          (value_identifier)))
+      (unit))))

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -103,3 +103,44 @@ let () = noop
 ---
 
 (source_file (let_binding (unit) (value_identifier)))
+
+============================================
+And (Primitives)
+============================================
+
+let a = 5 and b = 4
+
+---
+
+(source_file
+  (let_binding
+    (value_identifier)
+    (number)
+    (value_identifier)
+    (number)))
+
+============================================
+And (Fuctions)
+============================================
+
+let rec a = x => x + b(x) and b = y => y - 1
+
+---
+
+(source_file
+  (let_binding
+    (value_identifier)
+    (function
+      (value_identifier)
+      (binary_expression
+        (value_identifier)
+        (call_expression
+          (value_identifier)
+          (arguments
+            (value_identifier)))))
+    (value_identifier)
+    (function
+      (value_identifier)
+      (binary_expression
+        (value_identifier)
+        (number)))))   

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -316,3 +316,25 @@ and teacher = {
             (type_identifier)
             (type_arguments
               (type_identifier))))))))
+
+
+===========================================
+Labled function with uncurried
+===========================================
+      
+type test = (. ~attr: string) => unit
+
+---
+
+(source_file
+  (type_declaration
+    (type_identifier)
+    (function_type
+      (function_type_parameters
+        (parameter
+          (uncurry)
+          (labeled_parameter
+            (value_identifier)
+            (type_annotation
+              (type_identifier)))))
+      (unit_type))))


### PR DESCRIPTION
Hey there again!

This PR adds:
1. GraphQL injection point
2. Add `injections.scm` for both JS and GraphQL
3. Make `and` and token and add it to keyword `hightlights.scm`
4. Parse let-and statements (`let a = 5 and b = 4`)
5. Parse uncurried labelled function type declarations `type test = (. ~attr: string) => unit`

`tree-sitter test` passes as does `make test_wild`!

Thanks!