### PR TITLE
Handle more wild cases

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -685,6 +685,7 @@ module.exports = grammar({
         $.positional_parameter,
         $.labeled_parameter,
         $.unit,
+        $.type_parameter,
       ),
     ),
 
@@ -699,6 +700,11 @@ module.exports = grammar({
       optional($.as_aliasing),
       optional($.type_annotation),
       optional(field('default_value', $._labeled_parameter_default_value)),
+    ),
+
+    type_parameter: $ => seq(
+      'type',
+      $.type_identifier,
     ),
 
     _labeled_parameter_default_value: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1144,7 +1144,10 @@ module.exports = grammar({
       ),
     ),
 
-    type_identifier: $ => /[a-z_'][a-zA-Z0-9_]*/,
+    type_identifier: $ => choice(
+      /[a-z_'][a-zA-Z0-9_]*/,
+      $._escape_identifier,
+    ),
 
     value_identifier: $ => choice(
       /[a-z_][a-zA-Z0-9_']*/,

--- a/grammar.js
+++ b/grammar.js
@@ -242,6 +242,7 @@ module.exports = grammar({
 
     type_annotation: $ => seq(
       ':',
+      repeat($.decorator),
       $._inline_type,
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1154,7 +1154,7 @@ module.exports = grammar({
       $._escape_identifier,
     ),
 
-    _escape_identifier: $ => token(seq('\\', '"', /[^"]+/ , '"')),
+    _escape_identifier: $ => token(seq('\\"', /[^"]+/ , '"')),
 
     module_identifier: $ => /[A-Z][a-zA-Z0-9_]*/,
 

--- a/grammar.js
+++ b/grammar.js
@@ -330,8 +330,8 @@ module.exports = grammar({
       '{',
       choice(
         commaSep1t($._object_type_field),
-        seq('.', commaSep($._object_type_field)),
-        seq('..', commaSep($._object_type_field)),
+        seq('.', commaSept($._object_type_field)),
+        seq('..', commaSept($._object_type_field)),
       ),
       '}',
     ),
@@ -350,7 +350,9 @@ module.exports = grammar({
     ),
 
     type_arguments: $ => seq(
-      '<', commaSep1($._type), optional(','), '>'
+      '<',
+      commaSep1t($._type),
+      '>'
     ),
 
     function_type: $ => prec.left(seq(
@@ -366,7 +368,7 @@ module.exports = grammar({
 
     _function_type_parameter_list: $ => seq(
       '(',
-      commaSep(alias($.function_type_parameter, $.parameter)),
+      commaSept(alias($.function_type_parameter, $.parameter)),
       ')',
     ),
 
@@ -501,8 +503,8 @@ module.exports = grammar({
       '{',
       choice(
         commaSep1t($._object_field),
-        seq('.', commaSep($._object_field)),
-        seq('..', commaSep($._object_field)),
+        seq('.', commaSept($._object_field)),
+        seq('..', commaSept($._object_field)),
       ),
       '}',
     ),
@@ -523,8 +525,7 @@ module.exports = grammar({
 
     array: $ => seq(
       '[',
-      commaSep($.expression),
-      optional(','),
+      commaSept($.expression),
       ']'
     ),
 
@@ -909,7 +910,7 @@ module.exports = grammar({
 
     decorator_arguments: $ => seq(
       '(',
-      commaSep($.expression),
+      commaSept($.expression),
       ')',
     ),
 
@@ -1065,8 +1066,7 @@ module.exports = grammar({
 
     variant_arguments: $ => seq(
       '(',
-      commaSep($.expression),
-      optional(','),
+      commaSept($.expression),
       ')',
     ),
 
@@ -1290,4 +1290,8 @@ function commaSep2t(rule) {
 
 function commaSep(rule) {
   return optional(commaSep1(rule));
+}
+
+function commaSept(rule) {
+  return optional(commaSep1t(rule));
 }

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -65,6 +65,26 @@ Type annotations
       body: (number))))
 
 ===================================================
+Type arguments
+===================================================
+
+let foo = (type a, x: 'a): a => x
+
+---
+
+(source_file
+  (let_binding
+    (value_identifier)
+    (function
+      (formal_parameters
+        (type_parameter (type_identifier))
+        (positional_parameter
+          (value_identifier)
+          (type_annotation (type_identifier))))
+      (type_annotation (type_identifier))
+      (value_identifier))))
+
+===================================================
 Parameter defaults
 ===================================================
 

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -222,6 +222,12 @@ external _makeStyles: ({..}, . unit) => {..} = "makeStyles"
 external pushState: (Dom.history, @as(json`null`) _, @as("") _, ~href: string) => unit =
   "pushState"
 
+@send
+external add: (
+  t,
+  ~option: @unwrap [#Option(Dom.htmlOptionElement) | #OptGroup(Dom.htmlOptGroupElement)]
+) => unit = "add"
+
 ---
 
 (source_file
@@ -280,6 +286,30 @@ external pushState: (Dom.history, @as(json`null`) _, @as("") _, ~href: string) =
             (parameter
               (labeled_parameter
                 (value_identifier) (type_annotation (type_identifier)))))
+          (unit_type)))
+        (string (string_fragment))))
+  (decorated
+    (decorator (decorator_identifier))
+    (external_declaration
+      (value_identifier)
+      (type_annotation
+        (function_type
+          (function_type_parameters
+            (parameter (type_identifier))
+            (parameter
+              (labeled_parameter
+                (value_identifier)
+                (type_annotation
+                  (decorator (decorator_identifier))
+                  (polyvar_type
+                    (polyvar_declaration
+                      (polyvar_identifier)
+                      (polyvar_parameters
+                        (type_identifier_path (module_identifier) (type_identifier))))
+                    (polyvar_declaration
+                      (polyvar_identifier)
+                      (polyvar_parameters
+                        (type_identifier_path (module_identifier) (type_identifier)))))))))
           (unit_type)))
         (string (string_fragment)))))
 

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -225,7 +225,7 @@ external pushState: (Dom.history, @as(json`null`) _, @as("") _, ~href: string) =
 @send
 external add: (
   t,
-  ~option: @unwrap [#Option(Dom.htmlOptionElement) | #OptGroup(Dom.htmlOptGroupElement)]
+  ~option: @unwrap [#Option(Dom.htmlOptionElement) | #OptGroup(Dom.htmlOptGroupElement)],
 ) => unit = "add"
 
 ---

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -3,10 +3,12 @@ Opaque
 ===========================================
 
 type t
+type \"type"
 
 ---
 
 (source_file
+ (type_declaration (type_identifier))
  (type_declaration (type_identifier)))
 
 ===========================================
@@ -321,7 +323,7 @@ and teacher = {
 ===========================================
 Labled function with uncurried
 ===========================================
-      
+
 type test = (. ~attr: string) => unit
 
 ---


### PR DESCRIPTION
- Allow trailing commas in more cases
- `func(type a, x: 'a)`
- `func(x: @unwrap [#a(#foo), #b(#bar)])`
- `type \"type" = t"`