### PR TITLE
feat: add support for decorators in variant's type declaration

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -72,6 +72,7 @@ module.exports = grammar({
     [$.variant_identifier, $.module_identifier],
     [$.variant],
     [$.variant, $.variant_pattern],
+    [$.variant_declaration, $.function_type_parameter],
     [$.polyvar],
     [$.polyvar, $.polyvar_pattern],
     [$._pattern],
@@ -278,6 +279,7 @@ module.exports = grammar({
     )),
 
     variant_declaration: $ => prec.right(seq(
+      optional($.decorator),
       $.variant_identifier,
       optional($.variant_parameters),
       optional($.type_annotation),

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -99,6 +99,7 @@ Variant
 
 type t =
   | A
+  | @live("t.D") D
   | B(anotherType)
   | C({foo: int, bar: string})
 
@@ -109,6 +110,9 @@ type t =
     (type_identifier)
     (variant_type
       (variant_declaration (variant_identifier))
+      (variant_declaration
+        (decorator (decorator_identifier) (decorator_arguments (string (string_fragment))))
+        (variant_identifier))
       (variant_declaration
         (variant_identifier) (variant_parameters (type_identifier)))
       (variant_declaration


### PR DESCRIPTION
Sometimes we can add decorators during variant declarations, in this case with [reanalyze](https://github.com/rescript-association/reanalyze)

This PR add the support for decorators in this case