### PR TITLE
feat: support type annontation on tuple destructuring

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -82,6 +82,7 @@ module.exports = grammar({
     [$.decorator],
     [$._statement, $._one_or_more_statements],
     [$._simple_extension],
+    [$._inline_type, $.function_type_parameters],
   ],
 
   rules: {
@@ -684,16 +685,10 @@ module.exports = grammar({
       optional($.uncurry),
       choice(
         $._pattern,
-        $.positional_parameter,
         $.labeled_parameter,
         $.unit,
         $.type_parameter,
       ),
-    ),
-
-    positional_parameter: $ => seq(
-      $._pattern,
-      $.type_annotation,
     ),
 
     labeled_parameter: $ => seq(
@@ -726,6 +721,7 @@ module.exports = grammar({
         $._literal_pattern,
         $._destructuring_pattern,
       )),
+      optional($.type_annotation),
       optional($.as_aliasing),
     )),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -62,7 +62,6 @@
 
 [
  (formal_parameters (value_identifier))
- (positional_parameter (value_identifier))
  (labeled_parameter (value_identifier))
 ] @parameter
 

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -59,7 +59,7 @@ Type annotations
   (expression_statement
     (function
       parameters: (formal_parameters
-        (positional_parameter (value_identifier) (type_annotation (type_identifier)))
+        (value_identifier) (type_annotation (type_identifier))
         (labeled_parameter (value_identifier) (type_annotation (type_identifier))))
       return_type: (type_annotation (type_identifier))
       body: (number))))
@@ -78,9 +78,8 @@ let foo = (type a, x: 'a): a => x
     (function
       (formal_parameters
         (type_parameter (type_identifier))
-        (positional_parameter
-          (value_identifier)
-          (type_annotation (type_identifier))))
+        (value_identifier)
+        (type_annotation (type_identifier)))
       (type_annotation (type_identifier))
       (value_identifier))))
 

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -20,6 +20,7 @@ Tuple destructuring
 ============================================
 
 let (a, b, (c, d)) = foo
+let (state: int, setState) = foo
 
 ---
 
@@ -32,6 +33,11 @@ let (a, b, (c, d)) = foo
         (tuple_pattern
           (tuple_item_pattern (value_identifier))
           (tuple_item_pattern (value_identifier)))))
+    (value_identifier))
+  (let_binding
+    (tuple_pattern
+       (tuple_item_pattern (value_identifier) (type_annotation (type_identifier)))
+       (tuple_item_pattern (value_identifier)))
     (value_identifier)))
 
 ============================================
@@ -143,12 +149,12 @@ let rec a = x => x + b(x) and b = y => y - 1
       (value_identifier)
       (binary_expression
         (value_identifier)
-        (number)))))   
-    
+        (number)))))
+
 ===========================================
 Labled function with uncurried
 ===========================================
-      
+
 let test = (. ~attr) => ()
 
 ---


### PR DESCRIPTION
I add support for type annotation in all patterns 

I remove the `positional_parameters` because it's now include in the pattern and didn't find a way to keep it. In fact, I'm not sure if it is still useful anymore