### PR TITLE
Fixes based on rescript-lang.org repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TS=yarn tree-sitter
 # for acceptance testing. The general idea: if `tree-sitter-rescript`
 # is 100% legit for this codebase, it should satisfy everyone.
 wild_github_repos := rescript-lang/rescript-react \
+										 rescript-association/rescript-lang.org \
 										 tinymce/rescript-webapi \
 										 cca-io/rescript-material-ui
 

--- a/grammar.js
+++ b/grammar.js
@@ -633,7 +633,7 @@ module.exports = grammar({
     raise_expression: $ => prec('call', seq(
       'raise',
       '(',
-      $.variant,
+      commaSep1t($.variant),
       ')',
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -160,7 +160,7 @@ module.exports = grammar({
       field('name', $.module_identifier),
       optional(seq(
         ':',
-        field('signature', choice($.block, $.module_expression)),
+        field('signature', choice($.block, $.module_expression, $.functor)),
       )),
       optional(seq(
         '=',

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1058,6 +1058,7 @@ Raise expression
 ===========================================
 
 raise(BadArgument({myMessage: "Oops!"}))
+raise(InvalidInput,)
 
 ---
 
@@ -1070,7 +1071,10 @@ raise(BadArgument({myMessage: "Oops!"}))
           (record
             (record_field
               (property_identifier)
-              (string (string_fragment)))))))))
+              (string (string_fragment))))))))
+  (expression_statement
+    (raise_expression
+      (variant (variant_identifier)))))
 
 ============================================
 Try-catch

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -146,6 +146,28 @@ module MyFunctor = (X: {type t}, Y: {type t}): {type tx; type ty} => {
         (type_declaration (type_identifier) (type_identifier_path (module_identifier) (type_identifier)))))))
 
 ===========================================
+Functor signature
+===========================================
+
+module Make: (Content: StaticContent) => {
+  let make: string => string
+}
+
+---
+
+(source_file
+  (module_declaration
+    (module_identifier)
+    (functor
+      (functor_parameters
+        (functor_parameter (module_identifier) (module_type_annotation (module_identifier))))
+      (block
+        (let_binding
+          (value_identifier)
+          (type_annotation
+            (function_type (function_type_parameters (type_identifier)) (type_identifier))))))))
+
+===========================================
 Functor use
 ===========================================
 


### PR DESCRIPTION
- Make https://github.com/rescript-association/rescript-lang.org repo a part of `test_wild` suite
- Fix multiple bugs found after that, making the repo 100% legit


Addresses #92 