### PR TITLE
support decorator before object property identifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -349,6 +349,7 @@ module.exports = grammar({
     _object_type_field: $ => alias($.object_type_field, $.field),
 
     object_type_field: $ => seq(
+      repeat($.decorator),
       alias($.string, $.property_identifier),
       ':',
       $._type,

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -314,6 +314,8 @@ type transitionCreateArgs = {
   easing: string,
 }
 
+type person = {@meth "say": (string, string) => unit}
+
 ---
 
 (source_file
@@ -324,7 +326,19 @@ type transitionCreateArgs = {
       (record_type
         (record_type_field
           (property_identifier)
-          (type_annotation (type_identifier)))))))
+          (type_annotation (type_identifier))))))
+
+  (type_declaration
+    (type_identifier)
+    (object_type
+      (field
+        (decorator (decorator_identifier))
+        (property_identifier (string_fragment))
+        (function_type
+          (function_type_parameters
+            (parameter (type_identifier))
+            (parameter (type_identifier)))
+          (unit_type))))))
 
 ===========================================
 Mutually Recursive


### PR DESCRIPTION
```res
type person = {@meth "say": (string, string) => unit}
```

```
(source_file [0, 0] - [1, 0]
  (type_declaration [0, 0] - [0, 53]
    (type_identifier [0, 5] - [0, 11])
    (object_type [0, 14] - [0, 53]
      (ERROR [0, 15] - [0, 20]
        (decorator [0, 15] - [0, 20]
          (decorator_identifier [0, 16] - [0, 20])))
      (field [0, 21] - [0, 52]
        (property_identifier [0, 21] - [0, 26]
          (string_fragment [0, 22] - [0, 25]))
        (function_type [0, 28] - [0, 52]
          (function_type_parameters [0, 28] - [0, 44]
            (parameter [0, 29] - [0, 35]
              (type_identifier [0, 29] - [0, 35]))
            (parameter [0, 37] - [0, 43]
              (type_identifier [0, 37] - [0, 43])))
          (unit_type [0, 48] - [0, 52]))))))
```

See https://rescript-lang.org/syntax-lookup#meth-decorator