### PR TITLE
better support for decorator

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -403,6 +403,7 @@ module.exports = grammar({
       optional($.type_annotation),
       optional(seq(
         '=',
+        repeat($.decorator),
         $.expression,
         optional(seq(
           'and',
@@ -459,6 +460,7 @@ module.exports = grammar({
 
     parenthesized_expression: $ => seq(
       '(',
+      repeat($.decorator),
       $.expression,
       optional($.type_annotation),
       ')'
@@ -673,6 +675,7 @@ module.exports = grammar({
 
     _call_argument: $ => choice(
       seq(
+        repeat($.decorator),
         $.expression,
         optional($.type_annotation),
       ),

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -1,0 +1,55 @@
+============================================
+This decorator
+============================================
+
+foo(bar, @this (me, amount) => set(me, amount))
+
+---
+
+(source_file
+  (expression_statement
+    (call_expression
+      (value_identifier)
+      (arguments
+        (value_identifier)
+        (decorator (decorator_identifier))
+        (function
+          (formal_parameters
+            (value_identifier)
+            (value_identifier))
+          (call_expression
+            (value_identifier)
+            (arguments
+              (value_identifier)
+              (value_identifier))))))))
+
+============================================
+Reanalyze Decorator
+============================================
+
+let foo = (@doesNotRaise String.make)(12, ' ')
+
+let foo = @doesNotRaise String.make(12, ' ')
+
+---
+
+(source_file
+  (let_binding
+    (value_identifier)
+    (call_expression
+      (parenthesized_expression
+        (decorator (decorator_identifier))
+        (value_identifier_path
+          (module_identifier) (value_identifier)))
+      (arguments
+        (number)
+        (character))))
+
+  (let_binding
+    (value_identifier)
+    (decorator (decorator_identifier))
+    (call_expression
+      (value_identifier_path (module_identifier) (value_identifier))
+      (arguments
+        (number)
+        (character)))))


### PR DESCRIPTION
Support decorator in `call_arguments`

See https://rescript-lang.org/syntax-lookup#this-decorator
```res
setIncrement(counter, @this (me, amount) => me->setValue(me->getValue + amount))
```

Reanalyze decorators https://github.com/rescript-association/reanalyze/blob/master/EXCEPTION.md

```res
// Silence only the make function
let stringMake2 = (@doesNotRaise String.make)(12, ' ')

// Silence the entire call (including arguments to make)
let stringMake3 = @doesNotRaise String.make(12, ' ')
```