### PR TITLE
as_aliasing, add type annotation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -60,8 +60,8 @@ module.exports = grammar({
     [$.primary_expression, $.spread_pattern],
     [$.primary_expression, $._literal_pattern],
     [$.primary_expression, $._jsx_child],
-    [$.tuple_pattern, $._formal_parameter],
-    [$.primary_expression, $._formal_parameter],
+    [$.tuple_pattern, $.parameter],
+    [$.primary_expression, $.parameter],
     [$.primary_expression, $.record_field],
     [$.module_identifier_path, $.module_expression],
     [$.tuple_type, $.function_type_parameter],
@@ -86,8 +86,8 @@ module.exports = grammar({
     [$._statement, $._one_or_more_statements],
     [$._simple_extension],
     [$._inline_type, $.function_type_parameters],
-    [$.primary_expression, $._formal_parameter, $._pattern],
-    [$._formal_parameter, $._pattern]
+    [$.primary_expression, $.parameter, $._pattern],
+    [$.parameter, $._pattern]
   ],
 
   rules: {
@@ -730,11 +730,11 @@ module.exports = grammar({
 
     formal_parameters: $ => seq(
       '(',
-      optional(commaSep1t($._formal_parameter)),
+      optional(commaSep1t($.parameter)),
       ')'
     ),
 
-    _formal_parameter: $ => seq(
+    parameter: $ => seq(
       optional($.uncurry),
       choice(
         $._pattern,

--- a/grammar.js
+++ b/grammar.js
@@ -661,10 +661,11 @@ module.exports = grammar({
       '}',
     ),
 
-    as_aliasing: $ => seq(
+    as_aliasing: $ => prec.left(seq(
       'as',
       $.value_identifier,
-    ),
+      optional($.type_annotation)
+    )),
 
     assert_statement: $ => seq('assert', $.expression),
 

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -15,8 +15,8 @@ foo(bar, @this (me, amount) => set(me, amount))
         (decorator (decorator_identifier))
         (function
           (formal_parameters
-            (value_identifier)
-            (value_identifier))
+            (parameter (value_identifier))
+            (parameter (value_identifier)))
           (call_expression
             (value_identifier)
             (arguments

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1085,8 +1085,8 @@ module Test = %graphql(`
         (value_identifier)
         (function
           parameters: (formal_parameters
-            (value_identifier)
-            (value_identifier))
+            (parameter (value_identifier))
+            (parameter (value_identifier)))
           body: (binary_expression
             left: (value_identifier)
             right: (value_identifier))))))
@@ -1339,13 +1339,14 @@ let f = ({name, _} as foo: T.t) => {}
     (value_identifier)
     (function
       parameters: (formal_parameters
-        (record_pattern
-          (value_identifier)
-          (value_identifier))
-        (as_aliasing
-          (value_identifier)
-          (type_annotation
-            (type_identifier_path
-              (module_identifier)
-              (type_identifier)))))
+        (parameter
+          (record_pattern
+            (value_identifier)
+            (value_identifier))
+          (as_aliasing
+            (value_identifier)
+            (type_annotation
+              (type_identifier_path
+                (module_identifier)
+                (type_identifier))))))
       body: (block))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1325,3 +1325,27 @@ await foo->bar + 5
       (await_expression
         (pipe_expression (value_identifier) (value_identifier)))
       (number))))
+
+===========================================
+As aliasing
+===========================================
+
+let f = ({name, _} as foo: T.t) => {}
+
+---
+
+(source_file
+  (let_binding
+    (value_identifier)
+    (function
+      parameters: (formal_parameters
+        (record_pattern
+          (value_identifier)
+          (value_identifier))
+        (as_aliasing
+          (value_identifier)
+          (type_annotation
+            (type_identifier_path
+              (module_identifier)
+              (type_identifier)))))
+      body: (block))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -23,28 +23,36 @@ a => 1
     (formal_parameters)
     (number)))
   (expression_statement (function
-    (formal_parameters (value_identifier) (value_identifier))
+    (formal_parameters 
+      (parameter (value_identifier)) (parameter (value_identifier)))
     (number)))
   (expression_statement (function
-    (formal_parameters (value_identifier) (value_identifier))
+    (formal_parameters
+      (parameter (value_identifier))
+      (parameter (value_identifier)))
     (block
       (expression_statement (value_identifier)))))
   (expression_statement (function
-    (formal_parameters (value_identifier))
+    (formal_parameters
+      (parameter (value_identifier)))
     (number)))
-  (expression_statement (function
-    (formal_parameters (value_identifier) (value_identifier))
-    (number)))
-  (expression_statement (function
-    (formal_parameters (value_identifier) (value_identifier)) (number)))
   (expression_statement (function
     (formal_parameters
-      (value_identifier)
-      (uncurry)
-      (value_identifier)
-      (value_identifier)
-      (uncurry)
-      (value_identifier))
+      (parameter (value_identifier)) (parameter (value_identifier)))
+    (number)))
+  (expression_statement (function
+    (formal_parameters (parameter (value_identifier)) (parameter (value_identifier)))
+    (number)))
+  (expression_statement (function
+    (formal_parameters
+      (parameter (value_identifier))
+      (parameter
+        (uncurry)
+        (value_identifier))
+      (parameter (value_identifier))
+      (parameter
+        (uncurry)
+        (value_identifier)))
     (number))))
 
 ===================================================
@@ -59,8 +67,8 @@ Type annotations
   (expression_statement
     (function
       parameters: (formal_parameters
-        (value_identifier) (type_annotation (type_identifier))
-        (labeled_parameter (value_identifier) (type_annotation (type_identifier))))
+        (parameter (value_identifier) (type_annotation (type_identifier)))
+        (parameter (labeled_parameter (value_identifier) (type_annotation (type_identifier)))))
       return_type: (type_annotation (type_identifier))
       body: (number))))
 
@@ -77,9 +85,10 @@ let foo = (type a, x: 'a): a => x
     (value_identifier)
     (function
       (formal_parameters
-        (type_parameter (type_identifier))
-        (value_identifier)
-        (type_annotation (type_identifier)))
+        (parameter (type_parameter (type_identifier)))
+        (parameter
+          (value_identifier)
+          (type_annotation (type_identifier))))
       (type_annotation (type_identifier))
       (value_identifier))))
 
@@ -95,19 +104,23 @@ Parameter defaults
   (expression_statement
     (function
       parameters: (formal_parameters
-        (labeled_parameter
+        (parameter
+          (labeled_parameter
+            (value_identifier)
+            (type_annotation (type_identifier))
+            default_value: (number)))
+        (parameter
+          (labeled_parameter
+            (value_identifier)
+            default_value: (number)))
+        (parameter
+          (labeled_parameter
           (value_identifier)
-          (type_annotation (type_identifier))
-          default_value: (number))
-        (labeled_parameter
-          (value_identifier)
-          default_value: (number))
-        (labeled_parameter
-          (value_identifier)
-          (type_annotation (type_identifier)))
-        (labeled_parameter
-          (value_identifier))
-        (unit))
+          (type_annotation (type_identifier))))
+        (parameter
+          (labeled_parameter
+            (value_identifier)))
+        (parameter (unit)))
       body: (number))))
 
 ===================================================
@@ -122,11 +135,12 @@ Parameter aliasing
   (expression_statement
     (function
       (formal_parameters
-        (labeled_parameter
-          (value_identifier)
-          (as_aliasing (value_identifier))
-          (type_annotation (type_identifier))
-          (number)))
+        (parameter
+          (labeled_parameter
+            (value_identifier)
+            (as_aliasing (value_identifier))
+            (type_annotation (type_identifier))
+            (number))))
       (number))))
 
 ===================================================
@@ -140,14 +154,15 @@ Record pattern
 (source_file
   (expression_statement (function
     (formal_parameters
-      (record_pattern
-        (value_identifier)
-        (value_identifier)
+      (parameter
         (record_pattern
           (value_identifier)
-          (value_identifier))
-        (value_identifier)
-        (value_identifier)))
+          (value_identifier)
+          (record_pattern
+            (value_identifier)
+            (value_identifier))
+          (value_identifier)
+          (value_identifier))))
     (number))))
 
 ===================================================
@@ -178,7 +193,7 @@ Operator precendence
 
 (source_file
   (expression_statement (function
-    (formal_parameters (value_identifier))
+    (formal_parameters (parameter (value_identifier)))
     (binary_expression
       (pipe_expression
         (value_identifier)

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -203,7 +203,8 @@ let test = (. ~attr) => ()
     (value_identifier)
     (function
       (formal_parameters
-        (uncurry)
-        (labeled_parameter
-          (value_identifier)))
+        (parameter
+          (uncurry)
+          (labeled_parameter
+            (value_identifier))))
       (unit))))


### PR DESCRIPTION
```res
let f = ({name, _} as foo: T.t) => {}
```

```
(source_file [0, 0] - [4, 0]
  (let_binding [0, 0] - [0, 37]
    (value_identifier [0, 4] - [0, 5])
    (function [0, 8] - [0, 37]
      parameters: (formal_parameters [0, 8] - [0, 25]
        (record_pattern [0, 9] - [0, 18]
          (value_identifier [0, 10] - [0, 14])
          (value_identifier [0, 16] - [0, 17]))
        (as_aliasing [0, 19] - [0, 25]
          (value_identifier [0, 22] - [0, 25])))
      return_type: (type_annotation [0, 25] - [0, 30]
        (type_identifier_path [0, 27] - [0, 30]
          (module_identifier [0, 27] - [0, 28])
          (type_identifier [0, 29] - [0, 30])))
      (ERROR [0, 30] - [0, 31])
      body: (block [0, 35] - [0, 37]))))

```

https://rescript-lang.org/try?code=LYewJgrgNgpgBAFTgXjgbwFBzgFwJ4AO8OK6AdgIbAwBccAzjgE4CWZA5gDRwXu1xscAXwwiM+InABmIEKTSVqdRqw7de-FW3ZjYJKaQAUaDUJ704IVuzYUodBADocAShQA+dFjgApeo6gQdkMrFhtKKEcNOABqOABGF1EMIA