### PR TITLE
support int64

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1279,12 +1279,19 @@ module.exports = grammar({
         )
       )
 
+      const int64 = seq(
+        optional(choice('-', '+')),
+        choice(decimal_integer_literal, binary_literal, octal_literal, hex_literal),
+        'L'
+      )
+
       return token(choice(
         hex_literal,
         decimal_literal,
         binary_literal,
         octal_literal,
         bigint_literal,
+        int64
       ))
     },
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -33,10 +33,24 @@ Numbers
 -3.0
 +3
 +3.0
+1L
+1_2_3L
+-1L
+-1_2_3L
+0b1_000_000L
+0xffffffffL
+0o1234L
 
 ---
 
 (source_file
+  (expression_statement (number))
+  (expression_statement (number))
+  (expression_statement (number))
+  (expression_statement (number))
+  (expression_statement (number))
+  (expression_statement (number))
+  (expression_statement (number))
   (expression_statement (number))
   (expression_statement (number))
   (expression_statement (number))


### PR DESCRIPTION
This type is not documented. I found it in dakrlang codebase https://github.com/darklang/dark/blob/1205eb27b1eadd94dd3378e3abb92663035cc245/client/src/app/IntegrationTest.res#L249

https://rescript-lang.org/try?code=DYUwLgBAlgdmBsAWCBeCBtAUBCBGAMgDTZ4D6ATKQMxEkC0BxODF1tOADAEa6kf99+7CBwAeAM0lTJwjgHtc5KolnC6HWYn4biAXUxA