### PR TITLE
allow exception assignment

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -219,6 +219,7 @@ module.exports = grammar({
       'exception',
       $.variant_identifier,
       optional($.variant_parameters),
+      optional(seq('=', choice($.variant_identifier, $.nested_variant_identifier)))
     ),
 
     type_declaration: $ => seq(

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -353,10 +353,20 @@ Exception declaration
 ===========================================
 
 exception InputClosed(string)
+exception Error = Failed
+exception Invalid = Errors.Invalid
 
 ---
 
 (source_file
   (exception_declaration
     (variant_identifier)
-    (variant_parameters (type_identifier))))
+    (variant_parameters (type_identifier)))
+  (exception_declaration
+    (variant_identifier)
+    (variant_identifier))
+  (exception_declaration
+    (variant_identifier)
+    (nested_variant_identifier
+      (module_identifier)
+      (variant_identifier))))


### PR DESCRIPTION
```res
module Error = {
  exception ParseError(string)
}

exception ParseError = Error.ParseError
```

```
(source_file [0, 0] - [5, 0]
  (module_declaration [0, 0] - [2, 1]
    name: (module_identifier [0, 7] - [0, 12])
    definition: (block [0, 15] - [2, 1]
      (exception_declaration [1, 2] - [1, 30]
        (variant_identifier [1, 12] - [1, 22])
        (variant_parameters [1, 22] - [1, 30]
          (type_identifier [1, 23] - [1, 29])))))
  (exception_declaration [4, 0] - [4, 39]
    (ERROR [4, 10] - [4, 29]
      (variant_identifier [4, 10] - [4, 20]))
    (variant_identifier [4, 29] - [4, 39])))
```

https://rescript-lang.org/try?code=LYewJgrgNgpgBAUQE5JEuBeOBvAUHOGADwGMYAHAFwEsQA7OABQEMkBnGZVJACjcqTU6AcwCUuAL65cxMlVoMW7TijSZEqpADolHLmlxA