### PR TITLE
support when clause

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -633,7 +633,7 @@ module.exports = grammar({
     ),
 
     switch_pattern_condition: $ => seq(
-      'if',
+      choice('if', 'when'),
       $.expression,
     ),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -116,6 +116,7 @@
   "if"
   "else"
   "switch"
+  "when"
 ] @conditional
 
 [

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -484,6 +484,7 @@ Switch of vars
 
 switch foo {
 | x if x > 42 && x < 99 => x
+| x when x > 100 => x
 | _ => 42
 }
 
@@ -499,6 +500,11 @@ switch foo {
           (binary_expression
             (binary_expression (value_identifier) (number))
             (binary_expression (value_identifier) (number))))
+        (expression_statement (value_identifier)))
+      (switch_match
+        (value_identifier)
+        (switch_pattern_condition
+          (binary_expression (value_identifier) (number)))
         (expression_statement (value_identifier)))
       (switch_match
         (value_identifier)


### PR DESCRIPTION
> Rescript versions < 9.0 had a when clause, not an if clause.  Rescript 9.0 changed when to if.  (when may still work, but is deprecated.)

https://rescript-lang.org/docs/manual/latest/pattern-matching-destructuring#if-clause

https://rescript-lang.org/try?code=DYUwLgBAZg9jEF4IEYAMyBQpIENEQGcB3ASzAGMALaOCAbwwB8IAPCEqViAPggBYATBABkwrgB4IATimJeAIhbymXIpRAA7LrzSo5EeeoBOIZcwD6++QGYBygL4YMQA