### PR TITLE
support spread object

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -348,11 +348,15 @@ module.exports = grammar({
 
     _object_type_field: $ => alias($.object_type_field, $.field),
 
-    object_type_field: $ => seq(
-      repeat($.decorator),
-      alias($.string, $.property_identifier),
-      ':',
-      $._type,
+    object_type_field: $ => choice(
+      seq('...', choice($.type_identifier, $.type_identifier_path)),
+      seq(
+        repeat($.decorator),
+        alias($.string, $.property_identifier),
+        ':',
+        $._type,
+      ),
+
     ),
 
     generic_type: $ => seq(

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -257,6 +257,7 @@ type t = {.. "my-field": int }
 type t = {
   "my-field": int,
   "my-field-two": string,
+  ...rest
 }
 
 ---
@@ -276,7 +277,8 @@ type t = {
     (type_identifier)
     (object_type
       (field (property_identifier (string_fragment)) (type_identifier))
-      (field (property_identifier (string_fragment)) (type_identifier)))))
+      (field (property_identifier (string_fragment)) (type_identifier))
+      (field (type_identifier)))))
 
 ===========================================
 Generic


### PR DESCRIPTION
```res
type point2d = {
  "x": float,
  "y": float,
}
type point3d = {
  ...point2d,
  "z": float,
}
```

```
(source_file [0, 0] - [8, 0]
  (type_declaration [0, 0] - [3, 1]
    (type_identifier [0, 5] - [0, 12])
    (object_type [0, 15] - [3, 1]
      (field [1, 2] - [1, 12]
        (property_identifier [1, 2] - [1, 5]
          (string_fragment [1, 3] - [1, 4]))
        (type_identifier [1, 7] - [1, 12]))
      (field [2, 2] - [2, 12]
        (property_identifier [2, 2] - [2, 5]
          (string_fragment [2, 3] - [2, 4]))
        (type_identifier [2, 7] - [2, 12]))))
  (type_declaration [4, 0] - [7, 1]
    (type_identifier [4, 5] - [4, 12])
    (object_type [4, 15] - [7, 1]
      (ERROR [5, 4] - [5, 13]
        (ERROR [5, 5] - [5, 7])
        (ERROR [5, 9] - [5, 10])
        (number [5, 10] - [5, 11])
        (ERROR [5, 11] - [5, 12]))
      (field [6, 2] - [6, 12]
        (property_identifier [6, 2] - [6, 5]
          (string_fragment [6, 3] - [6, 4]))
        (type_identifier [6, 7] - [6, 12])))))
```

See https://rescript-lang.org/docs/manual/latest/object#combine-types

Example: https://rescript-lang.org/try?code=LYewJgrgNgpgBAFTgXjgbwFBzgFwJ4AO8BIAlgHY4BMYK6ARAB70BccAZlCAIY4A0cenlYcuvAL4ZJGfETgkKOAMy1UaegC8RnHvzgA6Qwn0LKNabBxxgeAAplKbU8tXosg5mwCM+gAx93IREqPwDsTRElUKkMIA