### PR TITLE
support `as` in polyvar_type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -298,12 +298,13 @@ module.exports = grammar({
       ')',
     ),
 
-    polyvar_type: $ => seq(
+    polyvar_type: $ => prec.left(seq(
       choice('[', '[>', '[<',),
       optional('|'),
       barSep1($.polyvar_declaration),
       ']',
-    ),
+      optional(seq('as', $.type_identifier))
+    )),
 
     polyvar_declaration: $ => prec.right(
       choice(

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -190,6 +190,9 @@ type t = [>
   | anotherType
   ]
 
+
+type foo<'a> = [> #Blue | #DeepBlue | #LightBlue ] as 'a
+
 ---
 
 (source_file
@@ -203,7 +206,16 @@ type t = [>
       (polyvar_declaration (polyvar_identifier (polyvar_string (string_fragment))))
       (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration (decorator (decorator_identifier) (decorator_arguments (string (string_fragment)))) (polyvar_identifier))
-      (polyvar_declaration (type_identifier)))))
+      (polyvar_declaration (type_identifier))))
+
+  (type_declaration
+    (type_identifier)
+    (type_parameters (type_identifier))
+    (polyvar_type
+      (polyvar_declaration (polyvar_identifier))
+      (polyvar_declaration (polyvar_identifier))
+      (polyvar_declaration (polyvar_identifier))
+      (type_identifier))))
 
 ===========================================
 Function


### PR DESCRIPTION
```res
type basicBlueTone<'a> = [> #Blue | #DeepBlue | #LightBlue ] as 'a
```

```
(source_file [0, 0] - [1, 0]
  (ERROR [0, 0] - [0, 66]
    (type_identifier [0, 5] - [0, 18])
    (type_parameters [0, 18] - [0, 22]
      (type_identifier [0, 19] - [0, 21]))
    (function_type_parameters [0, 25] - [0, 60]
      (polyvar_type [0, 25] - [0, 60]
        (polyvar_declaration [0, 28] - [0, 33]
          (polyvar_identifier [0, 28] - [0, 33]))
        (polyvar_declaration [0, 36] - [0, 45]
          (polyvar_identifier [0, 36] - [0, 45]))
        (polyvar_declaration [0, 48] - [0, 58]
          (polyvar_identifier [0, 48] - [0, 58]))))
    (ERROR [0, 65] - [0, 66])))

```

https://rescript-lang.org/docs/manual/latest/polymorphic-variant#lower-bound-

https://rescript-lang.org/try?code=C4TwDgpgBARghgZwJYGMBCAbArhAKgewDsIAeAcjgD4oBeKAbWoGJMcoAfKJgEQgjFbROTADJIA5gAtgggLpREUCgChQkKCnwZ8AJ1qxEqQQWIl6LbEK69+gjlzFSZl+0wAKWHWAwRZlZco+wBpaugBcIdp6dO6e3hABatAA7roA1kiE4vrwyOiWJqTmHl4+rjYCLsKO0nbCcv5AA


