### PR TITLE
Fix variant pattern

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -87,7 +87,9 @@ module.exports = grammar({
     [$._simple_extension],
     [$._inline_type, $.function_type_parameters],
     [$.primary_expression, $.parameter, $._pattern],
-    [$.parameter, $._pattern]
+    [$.parameter, $._pattern],
+    [$.parameter, $._parenthesized_pattern],
+    [$._switch_value_pattern, $._parenthesized_pattern],
   ],
 
   rules: {
@@ -782,11 +784,14 @@ module.exports = grammar({
         $._literal_pattern,
         $._destructuring_pattern,
         $.polyvar_type_pattern,
-        $.unit
+        $.unit,
+        $._parenthesized_pattern
       )),
       optional($.type_annotation),
       optional($.as_aliasing),
     )),
+
+    _parenthesized_pattern: $ => seq('(', $._pattern, ')'),
 
     _destructuring_pattern: $ => choice(
       $.variant_pattern,

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -822,6 +822,7 @@ switch n {
           (variant_identifier)
           (formal_parameters
             (variant_pattern (variant_identifier))
+            (variant_pattern (variant_identifier))
             (variant_pattern (variant_identifier))))
           (expression_statement (number))))))
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -795,6 +795,7 @@ Switch parenthesized
 switch n {
 | (1 | 2) => 1
 | (n if n > 10 | n if n < 42) | 50 | (n if n > 100) => n
+| Some((This | That) | Unknow) => 0
 }
 
 ---
@@ -815,7 +816,14 @@ switch n {
         (number)
         (value_identifier)
         (switch_pattern_condition (binary_expression (value_identifier) (number)))
-        (expression_statement (value_identifier))))))
+        (expression_statement (value_identifier)))
+      (switch_match
+        (variant_pattern
+          (variant_identifier)
+          (formal_parameters
+            (variant_pattern (variant_identifier))
+            (variant_pattern (variant_identifier))))
+          (expression_statement (number))))))
 
 ===========================================
 Switch ranges


### PR DESCRIPTION
More cases with parentheses in `switch_match`. Now inside variant.

```res
switch n {
| (1 | 2) => 1
| (n if n > 10 | n if n < 42) | 50 | (n if n > 100) => n
| Some((This | That) | Unknow) => 0
}
```

```
(source_file [0, 0] - [5, 0]
  (expression_statement [0, 0] - [4, 1]
    (switch_expression [0, 0] - [4, 1]
      (value_identifier [0, 7] - [0, 8])
      (switch_match [1, 0] - [1, 14]
        (number [1, 3] - [1, 4])
        (number [1, 7] - [1, 8])
        (expression_statement [1, 13] - [1, 14]
          (number [1, 13] - [1, 14])))
      (switch_match [2, 0] - [2, 56]
        (value_identifier [2, 3] - [2, 4])
        (switch_pattern_condition [2, 5] - [2, 14]
          (binary_expression [2, 8] - [2, 14]
            left: (value_identifier [2, 8] - [2, 9])
            right: (number [2, 12] - [2, 14])))
        (value_identifier [2, 17] - [2, 18])
        (switch_pattern_condition [2, 19] - [2, 28]
          (binary_expression [2, 22] - [2, 28]
            left: (value_identifier [2, 22] - [2, 23])
            right: (number [2, 26] - [2, 28])))
        (number [2, 32] - [2, 34])
        (value_identifier [2, 38] - [2, 39])
        (switch_pattern_condition [2, 40] - [2, 50]
          (binary_expression [2, 43] - [2, 50]
            left: (value_identifier [2, 43] - [2, 44])
            right: (number [2, 47] - [2, 50])))
        (expression_statement [2, 55] - [2, 56]
          (value_identifier [2, 55] - [2, 56])))
      (switch_match [3, 0] - [3, 35]
        (variant_pattern [3, 2] - [3, 30]
          (variant_identifier [3, 2] - [3, 6])
          (formal_parameters [3, 6] - [3, 30]
            (unit [3, 7] - [3, 20]
              (ERROR [3, 8] - [3, 19]
                (variant_pattern [3, 8] - [3, 12]
                  (variant_identifier [3, 8] - [3, 12]))
                (variant_pattern [3, 15] - [3, 19]
                  (variant_identifier [3, 15] - [3, 19]))))
            (variant_pattern [3, 23] - [3, 29]
              (variant_identifier [3, 23] - [3, 29]))))
        (expression_statement [3, 34] - [3, 35]
          (number [3, 34] - [3, 35]))))))
```

https://rescript-lang.org/try?code=C4TwDgpgBMULxQCoAsCWBnKAfJyCGsOAqgHYDWJA9gO4BQt61qwAxslAMqUC2EAFCgwBKKAG9aOLrz4C0mHCgIji5KtRFwAfDABOAVwgSoAOUoloWqADM8AG3SGAvlAC02gFLoAdLcoBzIA