### PR TITLE
support nested list_pattern with spread

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -871,11 +871,12 @@ module.exports = grammar({
 
     _collection_element_pattern: $ => seq(
       choice($._pattern, $.spread_pattern),
+      optional($.as_aliasing)
     ),
 
     spread_pattern: $ => seq(
       '...',
-      $.value_identifier,
+      choice($.value_identifier, $.list_pattern, $.array_pattern),
     ),
 
     _jsx_element: $ => choice($.jsx_element, $.jsx_self_closing_element),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -10,9 +10,11 @@
 [
   (type_identifier)
   (unit_type)
-  (list "list{")
-  (list_pattern "list{")
 ] @type
+
+
+(list "list{" @type)
+(list_pattern "list{" @type)
 
 ; To ensure that the closing curly bracket is the same color (scope) as the opening curly bracket
 (list "}" @type (#set! "priority" 105))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -638,6 +638,7 @@ switch foo {
 | list{1, 2, x} => 2
 | list{1, } => 3
 | list{...others} => 4
+| list{1, 2, ...list{b, ..._} as rest} => rest
 }
 
 ---
@@ -660,7 +661,17 @@ switch foo {
         (expression_statement (number)))
       (switch_match
         (list_pattern (spread_pattern (value_identifier)))
-        (expression_statement (number))))))
+        (expression_statement (number)))
+      (switch_match
+        (list_pattern
+          (number)
+          (number)
+          (spread_pattern
+            (list_pattern
+              (value_identifier)
+              (spread_pattern (value_identifier))))
+          (as_aliasing (value_identifier)))
+        (expression_statement (value_identifier))))))
 
 ===========================================
 Switch of arrays

--- a/test/highlight/expressions.res
+++ b/test/highlight/expressions.res
@@ -18,6 +18,9 @@ switch foo {
 //              ^ parameter
 //                    ^ punctuation.special
   42
+| list{1, 2, ...list{b, ..._} as rest} => rest
+//                   ^ parameter
+//                                ^ variable
 | exception Js.Exn.Error(_) => 99
 //^ exception
 }
@@ -47,3 +50,8 @@ try {
 | Js.Exn.Error(obj) => 3 // catch the JS exception
 }
 
+
+let c = list{a, ...list{b}}
+//          ^ type
+//           ^ variable
+//                      ^ variable


### PR DESCRIPTION
```res
switch foo {
| list{} => None
| list{1, 2, ...list{b, ..._} as rest} => Some(rest)
}
```

```
(source_file [0, 0] - [4, 0]
  (expression_statement [0, 0] - [3, 1]
    (switch_expression [0, 0] - [3, 1]
      (value_identifier [0, 7] - [0, 10])
      (switch_match [1, 0] - [1, 16]
        (list_pattern [1, 2] - [1, 8])
        (expression_statement [1, 12] - [1, 16]
          (variant [1, 12] - [1, 16]
            (variant_identifier [1, 12] - [1, 16]))))
      (switch_match [2, 0] - [2, 52]
        (list_pattern [2, 2] - [2, 29]
          (number [2, 7] - [2, 8])
          (number [2, 10] - [2, 11])
          (spread_pattern [2, 13] - [2, 20]
            (value_identifier [2, 16] - [2, 20]))
          (ERROR [2, 20] - [2, 22]
            (ERROR [2, 21] - [2, 22]))
          (spread_pattern [2, 24] - [2, 28]
            (value_identifier [2, 27] - [2, 28])))
        (as_aliasing [2, 30] - [2, 37]
          (value_identifier [2, 33] - [2, 37]))
        (ERROR [2, 37] - [2, 38])
        (expression_statement [2, 42] - [2, 52]
          (variant [2, 42] - [2, 52]
            (variant_identifier [2, 42] - [2, 46])
            (arguments [2, 46] - [2, 52]
              (value_identifier [2, 47] - [2, 51]))))))))
```

https://rescript-lang.org/try?code=DYUwLgBARhC8HAJYGcwG8BEAhA9lDANBBgFIjLIgYC+AULaJAE4gDGEADk4gHZgDKYAK4ATEH2RwIAQzgA+CGloQIyAO6IwrABYzFyiAB8EKdNXkQAFAEoIAejsQROHiAPGkqNKlHiw52AUSZAA6YBwAc0sMABlpVFVhMT4ALmIIAGoMxN8+a3cTLx9ksABGIhDKz3Riv1KAeQAzKArKgH1zeIgWVAC5AxVgsMiAJktavnKckobm-JUVLl4BJL9kSx6weYg6OlolvkFcsHXqzBJpV0JiAAlpJgA3EABPa4wABWkwblYAaxp8kA


### Change in highlights

Just highlight `list{` node and not its children.

Problem: `b` and `a` are highlighted as `@type`

![image](https://user-images.githubusercontent.com/16160544/189778761-d7c718fd-ef7e-451a-bfbd-bbb75b05d74a.png)
