### PR TITLE
support destructuring modules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -474,6 +474,7 @@ module.exports = grammar({
       $.pipe_expression,
       $.subscript_expression,
       $.member_expression,
+      $.module_destructuring_expression,
       $.extension_expression,
     ),
 
@@ -698,6 +699,10 @@ module.exports = grammar({
         $.block,
       ),
     )),
+
+    module_destructuring_expression: $ => seq(
+      'module', '(', choice($.module_identifier, $.module_identifier_path), ')'
+    ),
 
     call_arguments: $ => seq(
       '(',

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -13,6 +13,32 @@ open! Foo.Bar
     (module_identifier_path (module_identifier) (module_identifier))))
 
 ===========================================
+Module destructuring
+===========================================
+
+
+let {foo, bar} = module(User)
+let {baz, _} = module(User.Inner)
+
+---
+
+(source_file
+  (let_binding
+    (record_pattern
+      (value_identifier)
+      (value_identifier))
+    (module_destructuring_expression (module_identifier)))
+
+  (let_binding
+    (record_pattern
+      (value_identifier)
+      (value_identifier))
+    (module_destructuring_expression
+      (module_identifier_path
+        (module_identifier)
+        (module_identifier)))))
+
+===========================================
 Include
 ===========================================
 

--- a/test/highlight/modules.res
+++ b/test/highlight/modules.res
@@ -9,3 +9,8 @@ include NumericCurve({
 //      ^ namespace
   let foo = foo
 })
+
+let {baz, _} = module(User.Inner)
+//             ^ keyword
+//                    ^ namespace
+//                          ^ namespace


### PR DESCRIPTION
Currently the following code is parsed as a `call_expression`. Actually this is destructuring modules [https://rescript-lang.org/docs/manual/latest/module#destructuring-modules](https://rescript-lang.org/docs/manual/latest/module#destructuring-modules)

```res
let {baz, _} = module(User.Inner)
```

Before:
```
(source_file [0, 0] - [1, 0]
  (let_binding [0, 0] - [0, 33]
    (record_pattern [0, 4] - [0, 12]
      (value_identifier [0, 5] - [0, 8])
      (value_identifier [0, 10] - [0, 11]))
    (call_expression [0, 15] - [0, 33]
      function: (value_identifier [0, 15] - [0, 21])
      arguments: (arguments [0, 21] - [0, 33]
        (variant [0, 22] - [0, 32]
          (nested_variant_identifier [0, 22] - [0, 32]
            (module_identifier [0, 22] - [0, 26])
            (variant_identifier [0, 27] - [0, 32])))))))
```

After:

```
let_binding [0, 0] - [0, 33]
  record_pattern [0, 4] - [0, 12]
    value_identifier [0, 5] - [0, 8]
    value_identifier [0, 10] - [0, 11]
  module_destructuring_expression [0, 15] - [0, 33]
    module_identifier_path [0, 22] - [0, 32]
      module_identifier [0, 22] - [0, 26]
      module_identifier [0, 27] - [0, 32]
```