### PR TITLE
support pattern in as_aliasing rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -675,7 +675,7 @@ module.exports = grammar({
 
     as_aliasing: $ => prec.left(seq(
       'as',
-      $.value_identifier,
+      $._pattern,
       optional($.type_annotation)
     )),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -428,8 +428,8 @@ switch foo {
           (variant_identifier)
           (formal_parameters
             (value_identifier)
-            (as_aliasing (value_identifier))
-            (type_annotation (type_identifier))
+            (as_aliasing (value_identifier)
+            (type_annotation (type_identifier)))
             (record_pattern
               (value_identifier)
               (value_identifier))))
@@ -465,8 +465,8 @@ switch foo {
           (polyvar_identifier)
           (formal_parameters
             (value_identifier)
-            (as_aliasing (value_identifier))
-            (type_annotation (type_identifier))
+            (as_aliasing (value_identifier)
+            (type_annotation (type_identifier)))
             (number)))
         (as_aliasing (value_identifier))
         (expression_statement (number)))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -128,6 +128,7 @@ Parameter aliasing
 ===================================================
 
 (~xTheGreat as x: int=3) => 5
+(~p as (x, _)) => x
 
 ---
 
@@ -138,10 +139,22 @@ Parameter aliasing
         (parameter
           (labeled_parameter
             (value_identifier)
-            (as_aliasing (value_identifier))
-            (type_annotation (type_identifier))
+            (as_aliasing (value_identifier)
+            (type_annotation (type_identifier)))
             (number))))
-      (number))))
+      (number)))
+  
+  (expression_statement
+    (function
+      (formal_parameters
+        (parameter
+          (labeled_parameter
+            (value_identifier)
+            (as_aliasing
+              (tuple_pattern
+                (tuple_item_pattern (value_identifier))
+                (tuple_item_pattern (value_identifier)))))))
+      (value_identifier))))
 
 ===================================================
 Record pattern


### PR DESCRIPTION
```res
let polymorphicComponent = (~p as (x, _)) => React.string(x.name)
```

```
(source_file [0, 0] - [1, 0]
  (let_binding [0, 0] - [0, 65]
    (value_identifier [0, 4] - [0, 24])
    (function [0, 27] - [0, 65]
      parameters: (formal_parameters [0, 27] - [0, 41]
        (ERROR [0, 28] - [0, 33]
          (value_identifier [0, 29] - [0, 30]))
        (parameter [0, 34] - [0, 40]
          (tuple_pattern [0, 34] - [0, 40]
            (tuple_item_pattern [0, 35] - [0, 36]
              (value_identifier [0, 35] - [0, 36]))
            (tuple_item_pattern [0, 38] - [0, 39]
              (value_identifier [0, 38] - [0, 39])))))
      body: (call_expression [0, 45] - [0, 65]
        function: (value_identifier_path [0, 45] - [0, 57]
          (module_identifier [0, 45] - [0, 50])
          (value_identifier [0, 51] - [0, 57]))
        arguments: (arguments [0, 57] - [0, 65]
          (member_expression [0, 58] - [0, 64]
            record: (value_identifier [0, 58] - [0, 59])
            property: (property_identifier [0, 60] - [0, 64])))))))
```

https://github.com/rescript-association/reanalyze/blob/master/examples/deadcode/src/Hooks.res#L100