### PR TITLE
support decorator - take 2

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -91,6 +91,7 @@ module.exports = grammar({
     [$.parameter, $._pattern],
     [$.parameter, $._parenthesized_pattern],
     [$._switch_value_pattern, $._parenthesized_pattern],
+    [$.variant_declaration]
   ],
 
   rules: {
@@ -290,7 +291,7 @@ module.exports = grammar({
     )),
 
     variant_declaration: $ => prec.right(seq(
-      optional($.decorator),
+      repeat($.decorator),
       $.variant_identifier,
       optional($.variant_parameters),
       optional($.type_annotation),
@@ -498,6 +499,7 @@ module.exports = grammar({
         $._definition_signature
       ),
       '=>',
+      repeat($.decorator),
       field('body', $.expression),
     )),
 

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -31,6 +31,8 @@ let foo = (@doesNotRaise String.make)(12, ' ')
 
 let foo = @doesNotRaise String.make(12, ' ')
 
+let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
+
 ---
 
 (source_file
@@ -52,4 +54,16 @@ let foo = @doesNotRaise String.make(12, ' ')
       (value_identifier_path (module_identifier) (value_identifier))
       (arguments
         (number)
-        (character)))))
+        (character))))
+
+  (let_binding
+    (value_identifier)
+    (function
+      (formal_parameters)
+      (decorator (decorator_identifier))
+      (call_expression
+        (value_identifier_path (module_identifier) (module_identifier) (value_identifier))
+        (arguments
+          (array)
+          (number))))))
+


### PR DESCRIPTION
```res
let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
```

```
(source_file [0, 0] - [1, 0]
  (let_binding [0, 0] - [0, 59]
    (value_identifier [0, 4] - [0, 12])
    (ERROR [0, 15] - [0, 20]
      parameters: (formal_parameters [0, 15] - [0, 17]))
    (decorator [0, 21] - [0, 34]
      (decorator_identifier [0, 22] - [0, 34]))
    (call_expression [0, 35] - [0, 59]
      function: (value_identifier_path [0, 35] - [0, 52]
        (module_identifier [0, 35] - [0, 39])
        (module_identifier [0, 40] - [0, 45])
        (value_identifier [0, 46] - [0, 52]))
      arguments: (arguments [0, 52] - [0, 59]
        (array [0, 53] - [0, 55])
        (number [0, 57] - [0, 58])))))
```

https://github.com/rescript-association/reanalyze/blob/master/examples/deadcode/src/exception/Exn.res#L195


### Other Change

#67 added support for decorator in `variant_declaration` rule but using `optional`. I changed it to `repeat` to match more than one case