### PR TITLE
Better support for modules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -211,6 +211,7 @@ module.exports = grammar({
       ':',
       choice(
         $.module_expression,
+        seq('(', $.module_expression, ')'),
         $.block,
       )
     ),
@@ -1242,13 +1243,22 @@ module.exports = grammar({
       choice($.module_expression, $.block)
     )),
 
-    module_type_constraint: $ => seq(
-      $.module_expression,
+    _module_type_constraint: $ => seq(
       'with',
-      sep1('and',
+      sep1(choice('and', 'with'),
         choice($.constrain_module, $.constrain_type)
       ),
     ),
+
+    module_type_constraint: $ => prec.left(choice(
+      seq($.module_identifier_path, $._module_type_constraint),
+      seq(
+        '(',
+        $.module_identifier_path, $._module_type_constraint,
+        ')',
+        $._module_type_constraint
+      )
+    )),
 
     constrain_module: $ => seq(
       'module',

--- a/grammar.js
+++ b/grammar.js
@@ -151,7 +151,10 @@ module.exports = grammar({
 
     include_statement: $ => seq(
       'include',
-      choice($.module_expression, seq('(', $.module_expression, ')')),
+      choice(
+        $.module_expression,
+        seq('(', choice($.module_expression, $.functor_parameter), ')')
+      ),
     ),
 
     declaration: $ => choice(
@@ -200,7 +203,7 @@ module.exports = grammar({
     ),
 
     functor_parameter: $ => seq(
-      $.module_identifier,
+      $.module_identifier_path,
       $.module_type_annotation,
     ),
 
@@ -710,8 +713,8 @@ module.exports = grammar({
     module_pack: $ => seq(
       'module',
       '(',
-      choice($.module_expression, $.block),
-      optional(seq(':', $.module_expression)),
+      $._module_definition,
+      optional($.module_type_annotation),
       ')'
     ),
 
@@ -1240,8 +1243,6 @@ module.exports = grammar({
     )),
 
     module_type_constraint: $ => seq(
-      $.module_expression,
-      optional(':'),
       $.module_expression,
       'with',
       sep1('and',

--- a/grammar.js
+++ b/grammar.js
@@ -1267,12 +1267,11 @@ module.exports = grammar({
       $.module_identifier_path,
     ),
 
-    // TODO: use $.type_declaration rule
     constrain_type: $ => seq(
       'type',
-      $._type_identifier,
+      $._type,
       choice('=', ':='),
-      $._type_identifier
+      $._type,
     ),
 
     functor_use: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1260,7 +1260,7 @@ module.exports = grammar({
     constrain_type: $ => seq(
       'type',
       $._type_identifier,
-      '=',
+      choice('=', ':='),
       $._type_identifier
     ),
 

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -42,7 +42,9 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
       (parenthesized_expression
         (decorator (decorator_identifier))
         (value_identifier_path
-          (module_identifier) (value_identifier)))
+          (module_identifier_path
+            (module_identifier))
+          (value_identifier)))
       (arguments
         (number)
         (character))))
@@ -51,7 +53,10 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
     (value_identifier)
     (decorator (decorator_identifier))
     (call_expression
-      (value_identifier_path (module_identifier) (value_identifier))
+      (value_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (value_identifier))
       (arguments
         (number)
         (character))))
@@ -62,7 +67,12 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
       (formal_parameters)
       (decorator (decorator_identifier))
       (call_expression
-        (value_identifier_path (module_identifier) (module_identifier) (value_identifier))
+        (value_identifier_path
+          (module_identifier_path
+            (module_identifier_path
+              (module_identifier))
+            (module_identifier))
+          (value_identifier))
         (arguments
           (array)
           (number))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -41,14 +41,20 @@ Foo.Bar.baz.qux
 (source_file
   (expression_statement
     (value_identifier_path
-      (module_identifier)
-      (module_identifier) (value_identifier)))
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))
+      (value_identifier)))
   (expression_statement
     (member_expression
       (value_identifier_path
-        (module_identifier)
-        (module_identifier) (value_identifier))
-      (property_identifier))))
+        (module_identifier_path
+          (module_identifier_path
+            (module_identifier))
+          (module_identifier))
+        (value_identifier))
+    (property_identifier))))
 
 ===========================================
 Escape identifiers
@@ -149,7 +155,8 @@ f(raise)
             left: (pipe_expression
               (value_identifier)
               (value_identifier_path
-                (module_identifier)
+                (module_identifier_path
+                  (module_identifier))
                 (value_identifier)))
             right: (number))))))
   (expression_statement
@@ -158,7 +165,7 @@ f(raise)
       arguments: (arguments
         (number)
         (block
-          (open_statement (module_identifier))
+          (open_statement (module_identifier_path (module_identifier)))
           (expression_statement (value_identifier)))
         (labeled_argument
           label: (value_identifier)
@@ -208,9 +215,15 @@ foo->{
       (call_expression
         (pipe_expression
           (value_identifier)
-          (value_identifier_path (module_identifier) (value_identifier)))
+          (value_identifier_path
+            (module_identifier_path
+              (module_identifier))
+            (value_identifier)))
         (arguments (value_identifier)))
-      (value_identifier_path (module_identifier) (value_identifier))))
+      (value_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (value_identifier))))
   (expression_statement
     (pipe_expression
       (number)
@@ -234,7 +247,7 @@ foo->{
     (pipe_expression
       (value_identifier)
       (block
-        (open_statement (module_identifier))
+        (open_statement (module_identifier_path (module_identifier)))
         (expression_statement (value_identifier))))))
 
 ===========================================
@@ -274,12 +287,18 @@ Record
   (expression_statement
     (record
       (record_field
-        (property_identifier (module_identifier) (value_identifier))
+        (property_identifier
+          (module_identifier_path
+           (module_identifier))
+        (value_identifier))
         (number))))
   (expression_statement
     (record
       (record_field
-        (property_identifier (module_identifier) (value_identifier))
+        (property_identifier
+          (module_identifier_path
+            (module_identifier))
+          (value_identifier))
         (number))
       (record_field
         (property_identifier)
@@ -437,7 +456,8 @@ switch foo {
       (switch_match
         (variant_pattern
           (nested_variant_identifier
-            (module_identifier)
+            (module_identifier_path
+              (module_identifier))
             (variant_identifier)))
         (expression_statement (number))))))
 
@@ -473,7 +493,8 @@ switch foo {
       (switch_match
         (polyvar_type_pattern
           (type_identifier_path
-            (module_identifier)
+            (module_identifier_path
+              (module_identifier))
             (type_identifier)))
             (as_aliasing (value_identifier))
         (expression_statement (number))))))
@@ -728,7 +749,8 @@ switch (element->HtmlInputElement.ofElement) {
         (pipe_expression
           (value_identifier)
           (value_identifier_path
-            (module_identifier)
+            (module_identifier_path
+              (module_identifier))
             (value_identifier))))
       (switch_match
         (variant_pattern
@@ -738,14 +760,16 @@ switch (element->HtmlInputElement.ofElement) {
         (expression_statement
           (call_expression
             function: (value_identifier_path
-              (module_identifier)
+              (module_identifier_path
+                (module_identifier))
               (value_identifier))
             arguments: (arguments
               (value_identifier))))
         (expression_statement
           (call_expression
             function: (value_identifier_path
-              (module_identifier)
+              (module_identifier_path
+                (module_identifier))
               (value_identifier))
             arguments: (arguments
               (value_identifier)))))
@@ -774,7 +798,12 @@ switch parseExn(str) {
       (switch_match
         (exception
           (variant_pattern
-            (nested_variant_identifier (module_identifier) (module_identifier) (variant_identifier))
+            (nested_variant_identifier
+              (module_identifier_path
+               (module_identifier_path
+                (module_identifier))
+               (module_identifier))
+              (variant_identifier))
             (formal_parameters (value_identifier))))
         (expression_statement (number))))))
 
@@ -792,7 +821,7 @@ switch { open Mod; foo() } {
   (expression_statement
     (switch_expression
       (block
-        (open_statement (module_identifier))
+        (open_statement (module_identifier_path (module_identifier)))
         (expression_statement
           (call_expression (value_identifier) (arguments))))
       (switch_match
@@ -1055,7 +1084,10 @@ Foo((Obj.magic(v): string))
       (arguments
         (parenthesized_expression
           (call_expression
-            (value_identifier_path (module_identifier) (value_identifier))
+            (value_identifier_path
+              (module_identifier_path
+                (module_identifier))
+              (value_identifier))
             (arguments (value_identifier)))
           (type_annotation (type_identifier)))))))
 
@@ -1246,7 +1278,12 @@ try switch foo() {
         (expression_statement (number)))
       (switch_match
         (variant_pattern
-          (nested_variant_identifier (module_identifier) (module_identifier) (variant_identifier))
+          (nested_variant_identifier
+            (module_identifier_path
+              (module_identifier_path
+                (module_identifier))
+              (module_identifier))
+            (variant_identifier))
           (formal_parameters (value_identifier)))
         (expression_statement (number)))))
   (expression_statement
@@ -1258,7 +1295,12 @@ try switch foo() {
         (switch_match (value_identifier) (expression_statement (string (string_fragment)))))
       (switch_match
         (variant_pattern
-          (nested_variant_identifier (module_identifier) (module_identifier) (variant_identifier))
+          (nested_variant_identifier
+            (module_identifier_path
+              (module_identifier_path
+                (module_identifier))
+              (module_identifier))
+            (variant_identifier))
           (formal_parameters (value_identifier)))
         (expression_statement (string (string_fragment)))))))
 
@@ -1309,7 +1351,9 @@ for x in 1 downto 3 {
       (block
         (expression_statement
           (call_expression
-            (value_identifier_path (module_identifier) (value_identifier))
+            (value_identifier_path
+              (module_identifier_path (module_identifier))
+              (value_identifier))
             (arguments (value_identifier)))))))
   (expression_statement
     (for_expression
@@ -1319,7 +1363,9 @@ for x in 1 downto 3 {
       (block
         (expression_statement
           (call_expression
-            (value_identifier_path (module_identifier) (value_identifier))
+            (value_identifier_path
+              (module_identifier_path (module_identifier))
+              (value_identifier))
             (arguments (value_identifier))))))))
 
 ===========================================
@@ -1339,7 +1385,10 @@ while true {
       (block
         (expression_statement
           (call_expression
-            (value_identifier_path (module_identifier) (value_identifier))
+            (value_identifier_path
+              (module_identifier_path
+                (module_identifier))
+              (value_identifier))
             (arguments (string (string_fragment)))))))))
 
 ===========================================
@@ -1385,6 +1434,6 @@ let f = ({name, _} as foo: T.t) => {}
             (value_identifier)
             (type_annotation
               (type_identifier_path
-                (module_identifier)
+                (module_identifier_path (module_identifier))
                 (type_identifier))))))
       body: (block))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -210,7 +210,7 @@ Operator precendence
     (binary_expression
       (pipe_expression
         (value_identifier)
-        (value_identifier_path (module_identifier) (value_identifier)))
+        (value_identifier_path (module_identifier_path (module_identifier)) (value_identifier)))
       (number)))))
 
 ===================================================

--- a/test/corpus/jsx.txt
+++ b/test/corpus/jsx.txt
@@ -43,7 +43,7 @@ Simple JSX elements
   (expression_statement
     (jsx_element
       (jsx_opening_element (jsx_identifier))
-      (value_identifier_path (module_identifier) (value_identifier))
+      (value_identifier_path (module_identifier_path (module_identifier)) (value_identifier))
       (jsx_closing_element (jsx_identifier))))
 
   (expression_statement
@@ -148,7 +148,10 @@ Block children
             (block
               (expression_statement
                 (call_expression
-                  (value_identifier_path (module_identifier) (value_identifier))
+                  (value_identifier_path
+                    (module_identifier_path
+                      (module_identifier))
+                    (value_identifier))
                   (arguments (string (string_fragment))))))
             (jsx_closing_element (jsx_identifier)))))
       (jsx_closing_element (jsx_identifier)))))
@@ -197,7 +200,8 @@ Attribute Block
             (expression_statement
               (call_expression
                 (value_identifier_path
-                  (module_identifier)
+                  (module_identifier_path
+                    (module_identifier))
                   (value_identifier))
                 (arguments
                   (string
@@ -206,7 +210,7 @@ Attribute Block
           (property_identifier)
           (jsx_expression
             (open_statement
-              (module_identifier))
+              (module_identifier_path (module_identifier)))
             (expression_statement
               (record
                 (record_field

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -73,8 +73,10 @@ let {Bar.Bar.bar: bar} = foo
   (let_binding
     (record_pattern
       (value_identifier_path
-        (module_identifier)
-        (module_identifier)
+        (module_identifier_path
+          (module_identifier_path
+            (module_identifier))
+          (module_identifier))
         (value_identifier))
       (value_identifier))
     (value_identifier)))
@@ -263,15 +265,17 @@ let {baz, _} = module(User.Inner)
     (record_pattern
       (value_identifier)
       (value_identifier))
-    (module_pack_expression (module_identifier)))
-
+    (module_pack
+      (module_identifier_path
+        (module_identifier))))
   (let_binding
     (record_pattern
       (value_identifier)
       (value_identifier))
-    (module_pack_expression
+    (module_pack
       (module_identifier_path
-        (module_identifier)
+        (module_identifier_path
+          (module_identifier))
         (module_identifier)))))
 
 ===========================================
@@ -285,7 +289,7 @@ let foo = module(Bar)
 (source_file
   (let_binding
     (value_identifier)
-    (module_pack_expression (module_identifier))))
+    (module_pack (module_identifier_path (module_identifier)))))
 
 ===========================================
 Unpacking module

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -77,10 +77,12 @@ include module type of {
         (module_identifier))))
 
   (include_statement
-    (module_type_constraint
+    (functor_parameter
       (module_identifier_path (module_identifier))
-      (module_type_of
-        (module_identifier_path (module_identifier)))
+    (module_type_annotation
+      (module_type_constraint
+        (module_type_of
+          (module_identifier_path (module_identifier)))
       (constrain_module
         (module_identifier_path (module_identifier))
         (module_identifier_path
@@ -92,7 +94,7 @@ include module type of {
         (module_identifier_path
           (module_identifier_path
             (module_identifier))
-          (module_identifier)))))
+          (module_identifier)))))))
 
   (include_statement
     (module_type_of
@@ -201,7 +203,7 @@ module(SomeFunctor(unpack(x)))
   (expression_statement
     (module_pack
       (module_identifier_path (module_identifier))
-      (module_identifier_path (module_identifier))))
+      (module_type_annotation (module_identifier_path (module_identifier)))))
   (expression_statement
     (module_pack
       (block
@@ -209,7 +211,7 @@ module(SomeFunctor(unpack(x)))
         (let_binding
           (value_identifier)
           (string (string_fragment))))
-      (module_identifier_path (module_identifier))))
+      (module_type_annotation (module_identifier_path (module_identifier)))))
   (expression_statement
     (module_pack
       (functor_use
@@ -236,10 +238,10 @@ module MyFunctor = (X: {type t}, Y: {type t}): {type tx; type ty} => {
     definition: (functor
       parameters: (functor_parameters
         (functor_parameter
-          (module_identifier)
+          (module_identifier_path (module_identifier))
           (module_type_annotation (block (type_declaration (type_identifier)))))
         (functor_parameter
-          (module_identifier)
+          (module_identifier_path (module_identifier))
           (module_type_annotation (block (type_declaration (type_identifier))))))
       return_module_type: (module_type_annotation
           (block (type_declaration (type_identifier)) (type_declaration (type_identifier))))
@@ -262,7 +264,7 @@ module Make: (Content: StaticContent) => {
     (module_identifier)
     (functor
       (functor_parameters
-        (functor_parameter (module_identifier) (module_type_annotation (module_identifier_path (module_identifier)))))
+        (functor_parameter (module_identifier_path (module_identifier)) (module_type_annotation (module_identifier_path (module_identifier)))))
       (block
         (let_binding
           (value_identifier)
@@ -494,14 +496,15 @@ module(M: T with type t = a and type t = b)
 (source_file
   (expression_statement
     (module_pack
-      (module_type_constraint
-        (module_identifier_path
-          (module_identifier))
-        (module_identifier_path
-          (module_identifier))
-        (constrain_type
-          (type_identifier)
-          (type_identifier))
-        (constrain_type
-          (type_identifier)
-          (type_identifier))))))
+      (module_identifier_path
+        (module_identifier))
+      (module_type_annotation
+        (module_type_constraint
+          (module_identifier_path
+            (module_identifier))
+          (constrain_type
+            (type_identifier)
+            (type_identifier))
+          (constrain_type
+            (type_identifier)
+            (type_identifier)))))))

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -482,3 +482,26 @@ exception Invalid = Errors.Invalid
       (module_identifier_path
         (module_identifier))
       (variant_identifier))))
+
+=========================================
+Module Constraints
+=========================================
+
+module(M: T with type t = a and type t = b)
+
+---
+
+(source_file
+  (expression_statement
+    (module_pack
+      (module_type_constraint
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier_path
+          (module_identifier))
+        (constrain_type
+          (type_identifier)
+          (type_identifier))
+        (constrain_type
+          (type_identifier)
+          (type_identifier))))))

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -80,21 +80,21 @@ include module type of {
     (functor_parameter
       (module_identifier_path (module_identifier))
     (module_type_annotation
+      (module_type_of
       (module_type_constraint
-        (module_type_of
-          (module_identifier_path (module_identifier)))
-      (constrain_module
         (module_identifier_path (module_identifier))
-        (module_identifier_path
+        (constrain_module
+          (module_identifier_path (module_identifier))
           (module_identifier_path
-            (module_identifier))
-          (module_identifier)))
-      (constrain_module
-        (module_identifier_path (module_identifier))
-        (module_identifier_path
+            (module_identifier_path
+              (module_identifier))
+            (module_identifier)))
+        (constrain_module
+          (module_identifier_path (module_identifier))
           (module_identifier_path
-            (module_identifier))
-          (module_identifier)))))))
+            (module_identifier_path
+              (module_identifier))
+            (module_identifier))))))))
 
   (include_statement
     (module_type_of
@@ -491,20 +491,59 @@ Module Constraints
 
 module(M: T with type t = a and type t = b)
 
+module M = (): (T with type t = int) => {}
+
+module M = (Na: N, Nb: N): (
+  (S with type t = x) with type a = b
+) => {}
+
 ---
 
 (source_file
   (expression_statement
     (module_pack
-      (module_identifier_path
-        (module_identifier))
+      (module_identifier_path (module_identifier))
       (module_type_annotation
         (module_type_constraint
-          (module_identifier_path
-            (module_identifier))
+          (module_identifier_path (module_identifier))
           (constrain_type
             (type_identifier)
             (type_identifier))
           (constrain_type
             (type_identifier)
-            (type_identifier)))))))
+            (type_identifier))))))
+
+  (module_declaration
+    (module_identifier)
+    (functor
+      (functor_parameters)
+      (module_type_annotation
+        (module_type_constraint
+          (module_identifier_path (module_identifier)) 
+          (constrain_type
+            (type_identifier)
+            (type_identifier))))
+      (block)))
+
+  (module_declaration
+    (module_identifier)
+    (functor
+      (functor_parameters
+        (functor_parameter
+          (module_identifier_path (module_identifier))
+          (module_type_annotation
+            (module_identifier_path (module_identifier))))
+        (functor_parameter
+          (module_identifier_path (module_identifier))
+          (module_type_annotation
+            (module_identifier_path (module_identifier)))))
+      (module_type_annotation
+        (module_type_constraint
+          (module_identifier_path (module_identifier))
+          (constrain_type
+            (type_identifier)
+            (type_identifier))
+          (constrain_type
+            (type_identifier)
+            (type_identifier))))
+      (block))))

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -8,9 +8,13 @@ open! Foo.Bar
 ---
 
 (source_file
-  (open_statement (module_identifier))
   (open_statement
-    (module_identifier_path (module_identifier) (module_identifier))))
+    (module_identifier_path (module_identifier)))
+  (open_statement
+    (module_identifier_path
+      (module_identifier_path
+        (module_identifier))
+      (module_identifier))))
 
 ===========================================
 Include
@@ -34,42 +38,67 @@ include module type of {
 ---
 
 (source_file
-  (include_statement (module_identifier))
   (include_statement
-    (module_identifier_path (module_identifier) (module_identifier)))
+    (module_identifier_path
+      (module_identifier)))
+  (include_statement
+    (module_identifier_path
+      (module_identifier_path
+        (module_identifier))
+      (module_identifier)))
   (include_statement
     (functor_use
-      (module_identifier_path (module_identifier) (module_identifier))
-      (arguments (module_identifier))))
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))
+      (arguments (module_identifier_path (module_identifier)))))
   (include_statement
     (functor_use
-      (module_identifier_path (module_identifier) (module_identifier))
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))
       (arguments
         (block
           (type_declaration (type_identifier))
           (let_binding (value_identifier) (type_annotation (type_identifier)))))))
   (include_statement
     (module_type_of
-      (module_identifier_path (module_identifier) (module_identifier))))
-  
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))))
   (include_statement
     (module_type_of
-      (module_identifier_path (module_identifier) (module_identifier))))
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))))
 
   (include_statement
     (module_type_constraint
-      (module_identifier)
+      (module_identifier_path (module_identifier))
       (module_type_of
-        (module_identifier))
-      (module_identifier)
-      (module_identifier_path (module_identifier) (module_identifier))
-      (module_identifier)
-      (module_identifier_path (module_identifier) (module_identifier))))
+        (module_identifier_path (module_identifier)))
+      (constrain_module
+        (module_identifier_path (module_identifier))
+        (module_identifier_path
+          (module_identifier_path
+            (module_identifier))
+          (module_identifier)))
+      (constrain_module
+        (module_identifier_path (module_identifier))
+        (module_identifier_path
+          (module_identifier_path
+            (module_identifier))
+          (module_identifier)))))
 
   (include_statement
     (module_type_of
       (block
-        (include_statement (module_identifier))))))
+        (include_statement
+          (module_identifier_path (module_identifier)))))))
 
 ===========================================
 Simple definition
@@ -117,7 +146,10 @@ module MyModule: {
       (let_binding (value_identifier) (type_annotation (type_identifier)))))
   (module_declaration
     name: (module_identifier)
-    signature: (module_identifier_path (module_identifier) (module_identifier))
+    signature: (module_identifier_path
+      (module_identifier_path
+        (module_identifier))
+      (module_identifier))
     definition: (block (type_declaration (type_identifier))))
   (module_declaration
     name: (module_identifier)
@@ -140,7 +172,11 @@ module type t
     (block (type_declaration (type_identifier))))
   (module_declaration
     (module_identifier)
-    (module_type_of (module_identifier_path (module_identifier) (module_identifier))))
+    (module_type_of
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))))
   (module_declaration (type_identifier)))
 
 ===========================================
@@ -161,21 +197,23 @@ module(SomeFunctor(unpack(x)))
 
 (source_file
   (expression_statement
-    (module_pack_expression (module_identifier)))
+    (module_pack (module_identifier_path (module_identifier))))
   (expression_statement
-    (module_pack_expression (module_identifier) (module_identifier)))
+    (module_pack
+      (module_identifier_path (module_identifier))
+      (module_identifier_path (module_identifier))))
   (expression_statement
-    (module_pack_expression
+    (module_pack
       (block
         (type_declaration (type_identifier))
         (let_binding
           (value_identifier)
           (string (string_fragment))))
-      (module_identifier)))
+      (module_identifier_path (module_identifier))))
   (expression_statement
-    (module_pack_expression
+    (module_pack
       (functor_use
-        (module_identifier)
+        (module_identifier_path (module_identifier))
         (arguments
           (module_unpack
             (call_arguments (value_identifier))))))))
@@ -206,8 +244,8 @@ module MyFunctor = (X: {type t}, Y: {type t}): {type tx; type ty} => {
       return_module_type: (module_type_annotation
           (block (type_declaration (type_identifier)) (type_declaration (type_identifier))))
       body: (block
-        (type_declaration (type_identifier) (type_identifier_path (module_identifier) (type_identifier)))
-        (type_declaration (type_identifier) (type_identifier_path (module_identifier) (type_identifier)))))))
+        (type_declaration (type_identifier) (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))
+        (type_declaration (type_identifier) (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))))))
 
 ===========================================
 Functor signature
@@ -224,7 +262,7 @@ module Make: (Content: StaticContent) => {
     (module_identifier)
     (functor
       (functor_parameters
-        (functor_parameter (module_identifier) (module_type_annotation (module_identifier))))
+        (functor_parameter (module_identifier) (module_type_annotation (module_identifier_path (module_identifier)))))
       (block
         (let_binding
           (value_identifier)
@@ -243,10 +281,14 @@ module M = MyFunctor(Foo, Bar.Baz)
   (module_declaration
     (module_identifier)
     (functor_use
-      (module_identifier)
+      (module_identifier_path (module_identifier))
       (arguments
-        (module_identifier)
-        (module_identifier_path (module_identifier) (module_identifier))))))
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier_path
+          (module_identifier_path
+            (module_identifier))
+          (module_identifier))))))
 
 ===========================================
 Alias
@@ -260,7 +302,10 @@ module Q = Foo.Bar.Qux
   (module_declaration
     (module_identifier)
     (module_identifier_path
-      (module_identifier_path (module_identifier) (module_identifier))
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))
       (module_identifier))))
 
 ===========================================
@@ -276,8 +321,10 @@ module rec BYOBReader: {
 (source_file
   (module_declaration
     (module_identifier)
-    (block (include_statement (module_identifier)))
-    (module_identifier)))
+    (block
+      (include_statement
+        (module_identifier_path (module_identifier))))
+    (module_identifier_path (module_identifier))))
 
 ===========================================
 Definition through extension
@@ -362,7 +409,7 @@ external add: (
         (function_type
           (function_type_parameters
             (parameter
-              (type_identifier_path (module_identifier) (type_identifier)))
+              (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))
             (parameter
               (decorator (decorator_identifier) (decorator_arguments (template_string)))
               (type_identifier))
@@ -391,11 +438,11 @@ external add: (
                     (polyvar_declaration
                       (polyvar_identifier)
                       (polyvar_parameters
-                        (type_identifier_path (module_identifier) (type_identifier))))
+                        (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier))))
                     (polyvar_declaration
                       (polyvar_identifier)
                       (polyvar_parameters
-                        (type_identifier_path (module_identifier) (type_identifier)))))))))
+                        (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))))))))
           (unit_type)))
         (string (string_fragment)))))
 
@@ -432,5 +479,6 @@ exception Invalid = Errors.Invalid
   (exception_declaration
     (variant_identifier)
     (nested_variant_identifier
-      (module_identifier)
+      (module_identifier_path
+        (module_identifier))
       (variant_identifier))))

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -35,7 +35,11 @@ type t = Foo.Bar.qux
   (type_declaration
     (type_identifier)
     (type_identifier_path
-      (module_identifier) (module_identifier) (type_identifier))))
+      (module_identifier_path
+        (module_identifier_path
+          (module_identifier))
+        (module_identifier))
+      (type_identifier))))
 
 ===========================================
 Private
@@ -162,12 +166,14 @@ type t =
       (variant_declaration
         (variant_identifier)
         (variant_parameters
-          (module_pack_type (module_identifier))))
+          (module_pack
+            (module_identifier_path (module_identifier)))))
       (variant_declaration
         (variant_identifier)
         (variant_parameters
-          (module_pack_type
-            (type_identifier_path (module_identifier) (type_identifier))))))))
+          (module_pack
+            (type_identifier_path
+              (module_identifier_path (module_identifier)) (type_identifier))))))))
 
 ===========================================
 Annotated variant


### PR DESCRIPTION
**Add support for `module_pack` in parameters**

https://github.com/rescriptbr/rescript-urql/blob/main/src/Client.res#L248-L251

**Support `module_pack` after `as`**

https://github.com/rescriptbr/rescript-urql/blob/main/src/Client.res#L327

**Other changes**

1. Removed `module_pack_type`
2. A new rule to match this cases `repeat1(seq($.module_identifier, '.'))`
3. Two new rules `constrain_module` and `constrain_type`