### PR TITLE
Simplify grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -82,7 +82,6 @@ module.exports = grammar({
     [$.let_binding, $.ternary_expression],
     [$.variant_identifier, $.module_identifier],
     [$.variant, $.variant_pattern],
-    [$.variant],
     [$.variant_declaration, $.function_type_parameter],
     [$.variant_arguments, $._variant_pattern_parameters],
     [$.polyvar, $.polyvar_pattern],
@@ -1211,10 +1210,10 @@ module.exports = grammar({
       ')',
     ),
 
-    variant: $ => seq(
+    variant: $ => prec.right(seq(
       choice($.variant_identifier, $.nested_variant_identifier),
       optional(alias($.variant_arguments, $.arguments)),
-    ),
+    )),
 
     nested_variant_identifier: $ => seq(
       $.module_primary_expression,

--- a/grammar.js
+++ b/grammar.js
@@ -75,7 +75,6 @@ module.exports = grammar({
     [$.variant_identifier, $.module_identifier],
     [$.variant, $.variant_pattern],
     [$.variant_declaration, $.function_type_parameter],
-    [$.polyvar],
     [$.polyvar, $.polyvar_pattern],
     [$._pattern],
     [$._record_element, $.jsx_expression],
@@ -1222,10 +1221,10 @@ module.exports = grammar({
       ')',
     ),
 
-    polyvar: $ => seq(
+    polyvar: $ => prec.right(seq(
       $.polyvar_identifier,
       optional(alias($.variant_arguments, $.arguments)),
-    ),
+    )),
 
     _type_identifier: $ =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -64,7 +64,6 @@ module.exports = grammar({
     [$.tuple_pattern, $.parameter],
     [$.primary_expression, $.parameter],
     [$.primary_expression, $.record_field],
-    [$.module_identifier_path, $.module_expression],
     [$.tuple_type, $.function_type_parameter],
     [$.list, $.list_pattern],
     [$.array, $.array_pattern],

--- a/grammar.js
+++ b/grammar.js
@@ -35,6 +35,7 @@ module.exports = grammar({
       'call',
       $.spread_element,
       $.await_expression,
+      $.pipe_expression,
       'binary_times',
       'binary_pow',
       'binary_plus',
@@ -63,7 +64,6 @@ module.exports = grammar({
 
   conflicts: $ => [
     [$.unit, $.formal_parameters],
-    [$.pipe_expression, $.expression],
     [$.primary_expression, $._pattern],
     [$.primary_expression, $.record_pattern],
     [$.primary_expression, $.spread_pattern],

--- a/grammar.js
+++ b/grammar.js
@@ -82,7 +82,9 @@ module.exports = grammar({
     [$.let_binding, $.ternary_expression],
     [$.variant_identifier, $.module_identifier],
     [$.variant, $.variant_pattern],
+    [$.variant],
     [$.variant_declaration, $.function_type_parameter],
+    [$.variant_arguments, $._variant_pattern_parameters],
     [$.polyvar, $.polyvar_pattern],
     [$._pattern],
     [$._record_element, $.jsx_expression],
@@ -868,7 +870,7 @@ module.exports = grammar({
 
     _variant_pattern_parameters: $ => seq(
       '(',
-      commaSep1t($._variant_pattern_parameter),
+      commaSept($._variant_pattern_parameter),
       ')',
     ),
 
@@ -1209,10 +1211,10 @@ module.exports = grammar({
       ')',
     ),
 
-    variant: $ => prec.right(seq(
+    variant: $ => seq(
       choice($.variant_identifier, $.nested_variant_identifier),
       optional(alias($.variant_arguments, $.arguments)),
-    )),
+    ),
 
     nested_variant_identifier: $ => seq(
       $.module_primary_expression,

--- a/grammar.js
+++ b/grammar.js
@@ -50,6 +50,7 @@ module.exports = grammar({
     ],
     [$._jsx_attribute_value, $.pipe_expression],
     [$.function_type_parameters, $.function_type],
+    [$.module_expression, $.module_identifier_path],
     [$.module_identifier_path, $.module_type_of],
   ],
 
@@ -1240,6 +1241,7 @@ module.exports = grammar({
     ),
 
     module_expression: $ => choice(
+      $.module_identifier,
       $.module_identifier_path,
       $.type_identifier_path,
       $.module_type_of,

--- a/grammar.js
+++ b/grammar.js
@@ -1273,20 +1273,20 @@ module.exports = grammar({
       choice($.module_expression, $.block)
     )),
 
-    _module_type_constraint: $ => seq(
+    _module_type_constraint_with: $ => prec.right(seq(
       'with',
       sep1(choice('and', 'with'),
         choice($.constrain_module, $.constrain_type)
       ),
-    ),
+    )),
 
     module_type_constraint: $ => prec.left(choice(
-      seq($.module_identifier, $._module_type_constraint),
+      seq($.module_expression, $._module_type_constraint_with),
       seq(
         '(',
-        $.module_identifier, $._module_type_constraint,
+        $.module_expression, $._module_type_constraint_with,
         ')',
-        $._module_type_constraint
+        $._module_type_constraint_with
       )
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -28,6 +28,7 @@ module.exports = grammar({
   ],
 
   precedences: $ => [
+    // + - Operators -> precendence
     [
       'unary_not',
       'member',
@@ -49,10 +50,15 @@ module.exports = grammar({
       $.function,
       $.let_binding,
     ],
+    // Nested.Module.Path precendence
+    [
+      $.module_primary_expression,
+      $.value_identifier_path,
+      $.nested_variant_identifier,
+      $.module_identifier_path,
+    ],
     [$._jsx_attribute_value, $.pipe_expression],
     [$.function_type_parameters, $.function_type],
-    [$.module_expression, $.module_identifier_path],
-    [$.module_identifier_path, $.module_type_of],
   ],
 
   conflicts: $ => [
@@ -93,7 +99,6 @@ module.exports = grammar({
     [$._switch_value_pattern, $._parenthesized_pattern],
     [$.variant_declaration],
     [$.unit, $._function_type_parameter_list],
-    [$.module_primary_expression, $.module_identifier_path],
   ],
 
   rules: {
@@ -516,7 +521,7 @@ module.exports = grammar({
     ),
 
     value_identifier_path: $ => seq(
-      $.module_identifier_path,
+      $.module_primary_expression,
       '.',
       $.value_identifier,
     ),
@@ -1210,7 +1215,7 @@ module.exports = grammar({
     )),
 
     nested_variant_identifier: $ => seq(
-      $.module_identifier_path,
+      $.module_primary_expression,
       '.',
       $.variant_identifier
     ),
@@ -1257,7 +1262,7 @@ module.exports = grammar({
     ),
 
     module_identifier_path: $ => path(
-      $.module_identifier_path,
+      $.module_primary_expression,
       $.module_identifier,
     ),
 
@@ -1276,10 +1281,10 @@ module.exports = grammar({
     ),
 
     module_type_constraint: $ => prec.left(choice(
-      seq($.module_identifier_path, $._module_type_constraint),
+      seq($.module_identifier, $._module_type_constraint),
       seq(
         '(',
-        $.module_identifier_path, $._module_type_constraint,
+        $.module_identifier, $._module_type_constraint,
         ')',
         $._module_type_constraint
       )
@@ -1287,9 +1292,9 @@ module.exports = grammar({
 
     constrain_module: $ => seq(
       'module',
-      $.module_identifier_path,
+      $.module_identifier,
       choice('=', ':='),
-      $.module_identifier_path,
+      $.module_primary_expression,
     ),
 
     constrain_type: $ => seq(
@@ -1300,7 +1305,7 @@ module.exports = grammar({
     ),
 
     functor_use: $ => seq(
-      $.module_identifier_path,
+      $.module_primary_expression,
       alias($.functor_arguments, $.arguments),
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -203,7 +203,7 @@ module.exports = grammar({
     ),
 
     functor_parameter: $ => seq(
-      $.module_identifier_path,
+      $.module_identifier,
       $.module_type_annotation,
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -73,7 +73,6 @@ module.exports = grammar({
     [$._let_binding],
     [$.let_binding, $.ternary_expression],
     [$.variant_identifier, $.module_identifier],
-    [$.variant],
     [$.variant, $.variant_pattern],
     [$.variant_declaration, $.function_type_parameter],
     [$.polyvar],
@@ -1203,7 +1202,7 @@ module.exports = grammar({
       ')',
     ),
 
-    variant: $ => prec.dynamic(-1, seq(
+    variant: $ => prec.right(seq(
       choice($.variant_identifier, $.nested_variant_identifier),
       optional(alias($.variant_arguments, $.arguments)),
     )),

--- a/grammar.js
+++ b/grammar.js
@@ -24,6 +24,7 @@ module.exports = grammar({
     $.primary_expression,
     $._type,
     $.module_expression,
+    $.module_primary_expression,
   ],
 
   precedences: $ => [
@@ -91,7 +92,8 @@ module.exports = grammar({
     [$.parameter, $._parenthesized_pattern],
     [$._switch_value_pattern, $._parenthesized_pattern],
     [$.variant_declaration],
-    [$.unit, $._function_type_parameter_list]
+    [$.unit, $._function_type_parameter_list],
+    [$.module_primary_expression, $.module_identifier_path],
   ],
 
   rules: {
@@ -1235,18 +1237,22 @@ module.exports = grammar({
       ),
 
     type_identifier_path: $ => seq(
-      $.module_identifier_path,
+      $.module_primary_expression,
       '.',
       $.type_identifier
     ),
 
     module_expression: $ => choice(
-      $.module_identifier,
-      $.module_identifier_path,
+      $.module_primary_expression,
       $.type_identifier_path,
       $.module_type_of,
-      $.functor_use,
       $.module_type_constraint,
+    ),
+
+    module_primary_expression: $ => choice(
+      $.module_identifier,
+      $.module_identifier_path,
+      $.functor_use,
       $.module_unpack,
     ),
 

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -42,8 +42,7 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
       (parenthesized_expression
         (decorator (decorator_identifier))
         (value_identifier_path
-          (module_identifier_path
-            (module_identifier))
+          (module_identifier)
           (value_identifier)))
       (arguments
         (number)
@@ -54,8 +53,7 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
     (decorator (decorator_identifier))
     (call_expression
       (value_identifier_path
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (value_identifier))
       (arguments
         (number)
@@ -69,8 +67,7 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
       (call_expression
         (value_identifier_path
           (module_identifier_path
-            (module_identifier_path
-              (module_identifier))
+            (module_identifier)
             (module_identifier))
           (value_identifier))
         (arguments

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -493,8 +493,7 @@ switch foo {
       (switch_match
         (polyvar_type_pattern
           (type_identifier_path
-            (module_identifier_path
-              (module_identifier))
+            (module_identifier)
             (type_identifier)))
             (as_aliasing (value_identifier))
         (expression_statement (number))))))
@@ -1434,6 +1433,6 @@ let f = ({name, _} as foo: T.t) => {}
             (value_identifier)
             (type_annotation
               (type_identifier_path
-                (module_identifier_path (module_identifier))
+                (module_identifier)
                 (type_identifier))))))
       body: (block))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -42,16 +42,14 @@ Foo.Bar.baz.qux
   (expression_statement
     (value_identifier_path
       (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (module_identifier))
       (value_identifier)))
   (expression_statement
     (member_expression
       (value_identifier_path
         (module_identifier_path
-          (module_identifier_path
-            (module_identifier))
+          (module_identifier)
           (module_identifier))
         (value_identifier))
     (property_identifier))))
@@ -155,8 +153,7 @@ f(raise)
             left: (pipe_expression
               (value_identifier)
               (value_identifier_path
-                (module_identifier_path
-                  (module_identifier))
+                (module_identifier)
                 (value_identifier)))
             right: (number))))))
   (expression_statement
@@ -216,13 +213,11 @@ foo->{
         (pipe_expression
           (value_identifier)
           (value_identifier_path
-            (module_identifier_path
-              (module_identifier))
+            (module_identifier)
             (value_identifier)))
         (arguments (value_identifier)))
       (value_identifier_path
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (value_identifier))))
   (expression_statement
     (pipe_expression
@@ -287,18 +282,12 @@ Record
   (expression_statement
     (record
       (record_field
-        (property_identifier
-          (module_identifier_path
-           (module_identifier))
-        (value_identifier))
+        (property_identifier (module_identifier) (value_identifier))
         (number))))
   (expression_statement
     (record
       (record_field
-        (property_identifier
-          (module_identifier_path
-            (module_identifier))
-          (value_identifier))
+        (property_identifier (module_identifier) (value_identifier))
         (number))
       (record_field
         (property_identifier)
@@ -456,8 +445,7 @@ switch foo {
       (switch_match
         (variant_pattern
           (nested_variant_identifier
-            (module_identifier_path
-              (module_identifier))
+            (module_identifier)
             (variant_identifier)))
         (expression_statement (number))))))
 
@@ -747,10 +735,7 @@ switch (element->HtmlInputElement.ofElement) {
       (parenthesized_expression
         (pipe_expression
           (value_identifier)
-          (value_identifier_path
-            (module_identifier_path
-              (module_identifier))
-            (value_identifier))))
+          (value_identifier_path (module_identifier) (value_identifier))))
       (switch_match
         (variant_pattern
           (variant_identifier)
@@ -759,16 +744,14 @@ switch (element->HtmlInputElement.ofElement) {
         (expression_statement
           (call_expression
             function: (value_identifier_path
-              (module_identifier_path
-                (module_identifier))
+              (module_identifier)
               (value_identifier))
             arguments: (arguments
               (value_identifier))))
         (expression_statement
           (call_expression
             function: (value_identifier_path
-              (module_identifier_path
-                (module_identifier))
+              (module_identifier)
               (value_identifier))
             arguments: (arguments
               (value_identifier)))))
@@ -798,10 +781,7 @@ switch parseExn(str) {
         (exception
           (variant_pattern
             (nested_variant_identifier
-              (module_identifier_path
-               (module_identifier_path
-                (module_identifier))
-               (module_identifier))
+              (module_identifier_path (module_identifier) (module_identifier))
               (variant_identifier))
             (formal_parameters (value_identifier))))
         (expression_statement (number))))))
@@ -1083,10 +1063,7 @@ Foo((Obj.magic(v): string))
       (arguments
         (parenthesized_expression
           (call_expression
-            (value_identifier_path
-              (module_identifier_path
-                (module_identifier))
-              (value_identifier))
+            (value_identifier_path (module_identifier) (value_identifier))
             (arguments (value_identifier)))
           (type_annotation (type_identifier)))))))
 
@@ -1279,8 +1256,7 @@ try switch foo() {
         (variant_pattern
           (nested_variant_identifier
             (module_identifier_path
-              (module_identifier_path
-                (module_identifier))
+              (module_identifier)
               (module_identifier))
             (variant_identifier))
           (formal_parameters (value_identifier)))
@@ -1296,8 +1272,7 @@ try switch foo() {
         (variant_pattern
           (nested_variant_identifier
             (module_identifier_path
-              (module_identifier_path
-                (module_identifier))
+              (module_identifier)
               (module_identifier))
             (variant_identifier))
           (formal_parameters (value_identifier)))
@@ -1350,9 +1325,7 @@ for x in 1 downto 3 {
       (block
         (expression_statement
           (call_expression
-            (value_identifier_path
-              (module_identifier_path (module_identifier))
-              (value_identifier))
+            (value_identifier_path (module_identifier) (value_identifier))
             (arguments (value_identifier)))))))
   (expression_statement
     (for_expression
@@ -1362,9 +1335,7 @@ for x in 1 downto 3 {
       (block
         (expression_statement
           (call_expression
-            (value_identifier_path
-              (module_identifier_path (module_identifier))
-              (value_identifier))
+            (value_identifier_path (module_identifier) (value_identifier))
             (arguments (value_identifier))))))))
 
 ===========================================
@@ -1384,10 +1355,7 @@ while true {
       (block
         (expression_statement
           (call_expression
-            (value_identifier_path
-              (module_identifier_path
-                (module_identifier))
-              (value_identifier))
+            (value_identifier_path (module_identifier) (value_identifier))
             (arguments (string (string_fragment)))))))))
 
 ===========================================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -165,7 +165,7 @@ f(raise)
       arguments: (arguments
         (number)
         (block
-          (open_statement (module_identifier_path (module_identifier)))
+          (open_statement (module_identifier))
           (expression_statement (value_identifier)))
         (labeled_argument
           label: (value_identifier)
@@ -247,7 +247,7 @@ foo->{
     (pipe_expression
       (value_identifier)
       (block
-        (open_statement (module_identifier_path (module_identifier)))
+        (open_statement (module_identifier))
         (expression_statement (value_identifier))))))
 
 ===========================================
@@ -821,7 +821,7 @@ switch { open Mod; foo() } {
   (expression_statement
     (switch_expression
       (block
-        (open_statement (module_identifier_path (module_identifier)))
+        (open_statement (module_identifier))
         (expression_statement
           (call_expression (value_identifier) (arguments))))
       (switch_match

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -423,6 +423,7 @@ Switch of variants
 switch foo {
 | Some(x as qux: int, {y, z}) => x
 | Option.None => 42
+| Surprise() => 0
 }
 
 ---
@@ -447,6 +448,9 @@ switch foo {
           (nested_variant_identifier
             (module_identifier)
             (variant_identifier)))
+        (expression_statement (number)))
+      (switch_match
+        (variant_pattern (variant_identifier) (formal_parameters))
         (expression_statement (number))))))
 
 ===========================================

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -23,7 +23,7 @@ a => 1
     (formal_parameters)
     (number)))
   (expression_statement (function
-    (formal_parameters 
+    (formal_parameters
       (parameter (value_identifier)) (parameter (value_identifier)))
     (number)))
   (expression_statement (function
@@ -143,7 +143,7 @@ Parameter aliasing
             (type_annotation (type_identifier)))
             (number))))
       (number)))
-  
+
   (expression_statement
     (function
       (formal_parameters
@@ -210,7 +210,7 @@ Operator precendence
     (binary_expression
       (pipe_expression
         (value_identifier)
-        (value_identifier_path (module_identifier_path (module_identifier)) (value_identifier)))
+        (value_identifier_path (module_identifier) (value_identifier)))
       (number)))))
 
 ===================================================

--- a/test/corpus/jsx.txt
+++ b/test/corpus/jsx.txt
@@ -43,7 +43,7 @@ Simple JSX elements
   (expression_statement
     (jsx_element
       (jsx_opening_element (jsx_identifier))
-      (value_identifier_path (module_identifier_path (module_identifier)) (value_identifier))
+      (value_identifier_path (module_identifier) (value_identifier))
       (jsx_closing_element (jsx_identifier))))
 
   (expression_statement
@@ -148,10 +148,7 @@ Block children
             (block
               (expression_statement
                 (call_expression
-                  (value_identifier_path
-                    (module_identifier_path
-                      (module_identifier))
-                    (value_identifier))
+                  (value_identifier_path (module_identifier) (value_identifier))
                   (arguments (string (string_fragment))))))
             (jsx_closing_element (jsx_identifier)))))
       (jsx_closing_element (jsx_identifier)))))
@@ -200,8 +197,7 @@ Attribute Block
             (expression_statement
               (call_expression
                 (value_identifier_path
-                  (module_identifier_path
-                    (module_identifier))
+                  (module_identifier)
                   (value_identifier))
                 (arguments
                   (string

--- a/test/corpus/jsx.txt
+++ b/test/corpus/jsx.txt
@@ -209,8 +209,7 @@ Attribute Block
         (jsx_attribute
           (property_identifier)
           (jsx_expression
-            (open_statement
-              (module_identifier_path (module_identifier)))
+            (open_statement (module_identifier))
             (expression_statement
               (record
                 (record_field

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -296,9 +296,7 @@ let {baz, _} = module(User.Inner)
     (record_pattern
       (value_identifier)
       (value_identifier))
-    (module_pack
-      (module_identifier_path
-        (module_identifier))))
+    (module_pack (module_identifier)))
   (let_binding
     (record_pattern
       (value_identifier)
@@ -320,7 +318,7 @@ let foo = module(Bar)
 (source_file
   (let_binding
     (value_identifier)
-    (module_pack (module_identifier_path (module_identifier)))))
+    (module_pack (module_identifier))))
 
 ===========================================
 Unpacking module

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -74,8 +74,7 @@ let {Bar.Bar.bar: bar} = foo
     (record_pattern
       (value_identifier_path
         (module_identifier_path
-          (module_identifier_path
-            (module_identifier))
+          (module_identifier)
           (module_identifier))
         (value_identifier))
       (value_identifier))
@@ -303,8 +302,7 @@ let {baz, _} = module(User.Inner)
       (value_identifier))
     (module_pack
       (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (module_identifier)))))
 
 ===========================================

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -240,8 +240,12 @@ module MyFunctor = (X: {type t}, Y: {type t}): {type tx; type ty} => {
       return_module_type: (module_type_annotation
           (block (type_declaration (type_identifier)) (type_declaration (type_identifier))))
       body: (block
-        (type_declaration (type_identifier) (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))
-        (type_declaration (type_identifier) (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))))))
+        (type_declaration
+          (type_identifier)
+          (type_identifier_path (module_identifier) (type_identifier)))
+        (type_declaration
+          (type_identifier)
+          (type_identifier_path (module_identifier) (type_identifier)))))))
 
 ===========================================
 Functor signature
@@ -405,7 +409,7 @@ external add: (
         (function_type
           (function_type_parameters
             (parameter
-              (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))
+              (type_identifier_path (module_identifier) (type_identifier)))
             (parameter
               (decorator (decorator_identifier) (decorator_arguments (template_string)))
               (type_identifier))
@@ -434,11 +438,11 @@ external add: (
                     (polyvar_declaration
                       (polyvar_identifier)
                       (polyvar_parameters
-                        (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier))))
+                        (type_identifier_path (module_identifier) (type_identifier))))
                     (polyvar_declaration
                       (polyvar_identifier)
                       (polyvar_parameters
-                        (type_identifier_path (module_identifier_path (module_identifier)) (type_identifier)))))))))
+                        (type_identifier_path (module_identifier) (type_identifier)))))))))
           (unit_type)))
         (string (string_fragment)))))
 

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -11,8 +11,7 @@ open! Foo.Bar
   (open_statement (module_identifier))
   (open_statement
     (module_identifier_path
-      (module_identifier_path
-        (module_identifier))
+      (module_identifier)
       (module_identifier))))
 
 ===========================================
@@ -39,58 +38,37 @@ include module type of {
 (source_file
   (include_statement (module_identifier))
   (include_statement
-    (module_identifier_path
-      (module_identifier_path
-        (module_identifier))
-      (module_identifier)))
+    (module_identifier_path (module_identifier) (module_identifier)))
   (include_statement
     (functor_use
-      (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
-        (module_identifier))
+      (module_identifier_path (module_identifier) (module_identifier))
       (arguments (module_identifier))))
   (include_statement
     (functor_use
-      (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
-        (module_identifier))
+      (module_identifier_path (module_identifier) (module_identifier))
       (arguments
         (block
           (type_declaration (type_identifier))
           (let_binding (value_identifier) (type_annotation (type_identifier)))))))
   (include_statement
     (module_type_of
-      (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
-        (module_identifier))))
+      (module_identifier_path (module_identifier) (module_identifier))))
   (include_statement
     (module_type_of
-      (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
-        (module_identifier))))
+      (module_identifier_path (module_identifier) (module_identifier))))
 
   (include_statement
     (functor_parameter (module_identifier)
     (module_type_annotation
       (module_type_of
       (module_type_constraint
-        (module_identifier_path (module_identifier))
+        (module_identifier)
         (constrain_module
-          (module_identifier_path (module_identifier))
-          (module_identifier_path
-            (module_identifier_path
-              (module_identifier))
-            (module_identifier)))
+          (module_identifier)
+          (module_identifier_path (module_identifier) (module_identifier)))
         (constrain_module
-          (module_identifier_path (module_identifier))
-          (module_identifier_path
-            (module_identifier_path
-              (module_identifier))
-            (module_identifier))))))))
+          (module_identifier)
+          (module_identifier_path (module_identifier) (module_identifier))))))))
 
   (include_statement
     (module_type_of
@@ -142,10 +120,7 @@ module MyModule: {
       (let_binding (value_identifier) (type_annotation (type_identifier)))))
   (module_declaration
     name: (module_identifier)
-    signature: (module_identifier_path
-      (module_identifier_path
-        (module_identifier))
-      (module_identifier))
+    signature: (module_identifier_path (module_identifier) (module_identifier))
     definition: (block (type_declaration (type_identifier))))
   (module_declaration
     name: (module_identifier)
@@ -169,10 +144,7 @@ module type t
   (module_declaration
     (module_identifier)
     (module_type_of
-      (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
-        (module_identifier))))
+      (module_identifier_path (module_identifier) (module_identifier))))
   (module_declaration (type_identifier)))
 
 ===========================================
@@ -209,7 +181,7 @@ module(SomeFunctor(unpack(x)))
   (expression_statement
     (module_pack
       (functor_use
-        (module_identifier_path (module_identifier))
+        (module_identifier)
         (arguments
           (module_unpack
             (call_arguments (value_identifier))))))))
@@ -283,13 +255,10 @@ module M = MyFunctor(Foo, Bar.Baz)
   (module_declaration
     (module_identifier)
     (functor_use
-      (module_identifier_path (module_identifier))
+      (module_identifier)
       (arguments
         (module_identifier)
-        (module_identifier_path
-          (module_identifier_path
-            (module_identifier))
-          (module_identifier))))))
+        (module_identifier_path (module_identifier) (module_identifier))))))
 
 ===========================================
 Alias
@@ -304,8 +273,7 @@ module Q = Foo.Bar.Qux
     (module_identifier)
     (module_identifier_path
       (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (module_identifier))
       (module_identifier))))
 
@@ -479,8 +447,7 @@ exception Invalid = Errors.Invalid
   (exception_declaration
     (variant_identifier)
     (nested_variant_identifier
-      (module_identifier_path
-        (module_identifier))
+      (module_identifier)
       (variant_identifier))))
 
 =========================================
@@ -503,7 +470,7 @@ module M = (Na: N, Nb: N): (
       (module_identifier)
       (module_type_annotation
         (module_type_constraint
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (constrain_type
             (type_identifier)
             (type_identifier))
@@ -517,7 +484,7 @@ module M = (Na: N, Nb: N): (
       (functor_parameters)
       (module_type_annotation
         (module_type_constraint
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (constrain_type
             (type_identifier)
             (type_identifier))))
@@ -535,7 +502,7 @@ module M = (Na: N, Nb: N): (
           (module_type_annotation (module_identifier))))
       (module_type_annotation
         (module_type_constraint
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (constrain_type
             (type_identifier)
             (type_identifier))

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -8,8 +8,7 @@ open! Foo.Bar
 ---
 
 (source_file
-  (open_statement
-    (module_identifier_path (module_identifier)))
+  (open_statement (module_identifier))
   (open_statement
     (module_identifier_path
       (module_identifier_path
@@ -38,9 +37,7 @@ include module type of {
 ---
 
 (source_file
-  (include_statement
-    (module_identifier_path
-      (module_identifier)))
+  (include_statement (module_identifier))
   (include_statement
     (module_identifier_path
       (module_identifier_path
@@ -52,7 +49,7 @@ include module type of {
         (module_identifier_path
           (module_identifier))
         (module_identifier))
-      (arguments (module_identifier_path (module_identifier)))))
+      (arguments (module_identifier))))
   (include_statement
     (functor_use
       (module_identifier_path
@@ -98,9 +95,7 @@ include module type of {
 
   (include_statement
     (module_type_of
-      (block
-        (include_statement
-          (module_identifier_path (module_identifier)))))))
+      (block (include_statement (module_identifier))))))
 
 ===========================================
 Simple definition
@@ -199,11 +194,11 @@ module(SomeFunctor(unpack(x)))
 
 (source_file
   (expression_statement
-    (module_pack (module_identifier_path (module_identifier))))
+    (module_pack (module_identifier)))
   (expression_statement
     (module_pack
-      (module_identifier_path (module_identifier))
-      (module_type_annotation (module_identifier_path (module_identifier)))))
+      (module_identifier)
+      (module_type_annotation (module_identifier))))
   (expression_statement
     (module_pack
       (block
@@ -211,7 +206,7 @@ module(SomeFunctor(unpack(x)))
         (let_binding
           (value_identifier)
           (string (string_fragment))))
-      (module_type_annotation (module_identifier_path (module_identifier)))))
+      (module_type_annotation (module_identifier))))
   (expression_statement
     (module_pack
       (functor_use
@@ -264,7 +259,9 @@ module Make: (Content: StaticContent) => {
     (module_identifier)
     (functor
       (functor_parameters
-        (functor_parameter (module_identifier_path (module_identifier)) (module_type_annotation (module_identifier_path (module_identifier)))))
+        (functor_parameter
+          (module_identifier_path (module_identifier))
+          (module_type_annotation (module_identifier))))
       (block
         (let_binding
           (value_identifier)
@@ -285,8 +282,7 @@ module M = MyFunctor(Foo, Bar.Baz)
     (functor_use
       (module_identifier_path (module_identifier))
       (arguments
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (module_identifier_path
           (module_identifier_path
             (module_identifier))
@@ -324,9 +320,8 @@ module rec BYOBReader: {
   (module_declaration
     (module_identifier)
     (block
-      (include_statement
-        (module_identifier_path (module_identifier))))
-    (module_identifier_path (module_identifier))))
+      (include_statement (module_identifier)))
+    (module_identifier)))
 
 ===========================================
 Definition through extension
@@ -502,7 +497,7 @@ module M = (Na: N, Nb: N): (
 (source_file
   (expression_statement
     (module_pack
-      (module_identifier_path (module_identifier))
+      (module_identifier)
       (module_type_annotation
         (module_type_constraint
           (module_identifier_path (module_identifier))
@@ -519,7 +514,7 @@ module M = (Na: N, Nb: N): (
       (functor_parameters)
       (module_type_annotation
         (module_type_constraint
-          (module_identifier_path (module_identifier)) 
+          (module_identifier_path (module_identifier))
           (constrain_type
             (type_identifier)
             (type_identifier))))
@@ -531,12 +526,10 @@ module M = (Na: N, Nb: N): (
       (functor_parameters
         (functor_parameter
           (module_identifier_path (module_identifier))
-          (module_type_annotation
-            (module_identifier_path (module_identifier))))
+          (module_type_annotation (module_identifier)))
         (functor_parameter
           (module_identifier_path (module_identifier))
-          (module_type_annotation
-            (module_identifier_path (module_identifier)))))
+          (module_type_annotation (module_identifier))))
       (module_type_annotation
         (module_type_constraint
           (module_identifier_path (module_identifier))

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -60,15 +60,15 @@ include module type of {
   (include_statement
     (functor_parameter (module_identifier)
     (module_type_annotation
-      (module_type_of
       (module_type_constraint
-        (module_identifier)
+        (module_type_of (module_identifier))
         (constrain_module
           (module_identifier)
           (module_identifier_path (module_identifier) (module_identifier)))
         (constrain_module
           (module_identifier)
-          (module_identifier_path (module_identifier) (module_identifier))))))))
+          (module_identifier_path (module_identifier)
+          (module_identifier)))))))
 
   (include_statement
     (module_type_of

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -74,8 +74,7 @@ include module type of {
         (module_identifier))))
 
   (include_statement
-    (functor_parameter
-      (module_identifier_path (module_identifier))
+    (functor_parameter (module_identifier)
     (module_type_annotation
       (module_type_of
       (module_type_constraint
@@ -233,10 +232,10 @@ module MyFunctor = (X: {type t}, Y: {type t}): {type tx; type ty} => {
     definition: (functor
       parameters: (functor_parameters
         (functor_parameter
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (module_type_annotation (block (type_declaration (type_identifier)))))
         (functor_parameter
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (module_type_annotation (block (type_declaration (type_identifier))))))
       return_module_type: (module_type_annotation
           (block (type_declaration (type_identifier)) (type_declaration (type_identifier))))
@@ -260,7 +259,7 @@ module Make: (Content: StaticContent) => {
     (functor
       (functor_parameters
         (functor_parameter
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (module_type_annotation (module_identifier))))
       (block
         (let_binding
@@ -525,10 +524,10 @@ module M = (Na: N, Nb: N): (
     (functor
       (functor_parameters
         (functor_parameter
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (module_type_annotation (module_identifier)))
         (functor_parameter
-          (module_identifier_path (module_identifier))
+          (module_identifier)
           (module_type_annotation (module_identifier))))
       (module_type_annotation
         (module_type_constraint

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -36,8 +36,7 @@ type t = Foo.Bar.qux
     (type_identifier)
     (type_identifier_path
       (module_identifier_path
-        (module_identifier_path
-          (module_identifier))
+        (module_identifier)
         (module_identifier))
       (type_identifier))))
 

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -171,8 +171,7 @@ type t =
         (variant_identifier)
         (variant_parameters
           (module_pack
-            (type_identifier_path
-              (module_identifier_path (module_identifier)) (type_identifier))))))))
+            (type_identifier_path (module_identifier) (type_identifier))))))))
 
 ===========================================
 Annotated variant

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -166,8 +166,7 @@ type t =
       (variant_declaration
         (variant_identifier)
         (variant_parameters
-          (module_pack
-            (module_identifier_path (module_identifier)))))
+          (module_pack (module_identifier))))
       (variant_declaration
         (variant_identifier)
         (variant_parameters


### PR DESCRIPTION
- Remove a bunch of conflicts
- Generalize and relax module path-based access for many rules
- Remove superfluous `module_nested_path` nesting