### PR TITLE
fix break introduced in #143 for `constrain_module`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1310,7 +1310,7 @@ module.exports = grammar({
 
     constrain_module: $ => seq(
       'module',
-      $.module_identifier,
+      $.module_primary_expression,
       choice('=', ':='),
       $.module_primary_expression,
     ),

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -28,7 +28,7 @@ include Foo.Bar({
 
 include module type of Belt.Array
 include (module type of Belt.Array)
-include (Belt: module type of Belt with module Map := Belt.Map and module Result := Belt.Result)
+include (Belt: module type of Belt with module Map.Inner := Belt.Map and module Result := Belt.Result)
 include module type of {
   include T
 }
@@ -65,7 +65,8 @@ include module type of {
         (module_type_constraint
           (module_type_of (module_identifier))
           (constrain_module
-            (module_identifier)
+            (module_identifier_path
+              (module_identifier) (module_identifier))
             (module_identifier_path (module_identifier) (module_identifier)))
           (constrain_module
             (module_identifier)


### PR DESCRIPTION
```res
module type A = Foo with module X.Bar := Belt.Array
   and module X.Bar := Belt.Array
   and module X.Bar := Belt.Array
```

```
(source_file [0, 0] - [3, 0]
  (module_declaration [0, 0] - [2, 33]
    name: (module_identifier [0, 12] - [0, 13])
    definition: (module_type_constraint [0, 16] - [2, 33]
      (module_identifier [0, 16] - [0, 19])
      (constrain_module [0, 25] - [0, 51]
        (module_identifier [0, 32] - [0, 33])
        (ERROR [0, 33] - [0, 37])
        (module_identifier_path [0, 41] - [0, 51]
          (module_identifier [0, 41] - [0, 45])
          (module_identifier [0, 46] - [0, 51])))
      (constrain_module [1, 7] - [1, 33]
        (module_identifier [1, 14] - [1, 15])
        (ERROR [1, 15] - [1, 19])
        (module_identifier_path [1, 23] - [1, 33]
          (module_identifier [1, 23] - [1, 27])
          (module_identifier [1, 28] - [1, 33])))
      (constrain_module [2, 7] - [2, 33]
        (module_identifier [2, 14] - [2, 15])
        (ERROR [2, 15] - [2, 19])
        (module_identifier_path [2, 23] - [2, 33]
          (module_identifier [2, 23] - [2, 27])
          (module_identifier [2, 28] - [2, 33]))))))
../../test-filetypes/out.res	0 ms	(ERROR [0, 33] - [0, 37])
```