### PR TITLE
fix: allow `async` as valid identifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -107,6 +107,7 @@ module.exports = grammar({
     [$.variant_declaration],
     [$.unit, $._function_type_parameter_list],
     [$.functor_parameter, $.module_primary_expression, $.module_identifier_path],
+    [$._reserved_identifier, $.function]
   ],
 
   rules: {
@@ -1358,6 +1359,7 @@ module.exports = grammar({
 
     value_identifier: $ => choice(
       /[a-z_][a-zA-Z0-9_']*/,
+      $._reserved_identifier,
       $._escape_identifier,
     ),
 
@@ -1488,6 +1490,10 @@ module.exports = grammar({
     lparen: $ => alias($._lparen, '('),
     rparen: $ => alias($._rparen, ')'),
     uncurry: $ => '.',
+
+    _reserved_identifier: $ => choice(
+      'async'
+    )
   },
 });
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -112,12 +112,13 @@
   "type"
   "and"
   "assert"
-  "async"
   "await"
   "with"
   "unpack"
   "lazy"
 ] @keyword
+
+((function "async" @keyword))
 
 [
   "if"

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -12,6 +12,7 @@ a => 1
 (h, trailing,) => 5
 (set, kv) => 2
 (a, .b, c, .d) => 7
+(async) => 1
 
 ---
 
@@ -53,7 +54,12 @@ a => 1
       (parameter
         (uncurry)
         (value_identifier)))
-    (number))))
+    (number)))
+  (expression_statement
+    (function
+      (formal_parameters
+        (parameter (value_identifier)))
+      (number))))
 
 ===================================================
 Type annotations

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -7,6 +7,7 @@ let b = a
 let c = #foo
 let list = 1
 let a = list
+let async = 1
 export d = 5
 
 ---
@@ -17,6 +18,7 @@ export d = 5
   (let_binding (value_identifier) (polyvar (polyvar_identifier)))
   (let_binding (value_identifier) (number))
   (let_binding (value_identifier) (value_identifier))
+  (let_binding (value_identifier) (number))
   (let_binding (value_identifier) (number)))
 
 ============================================

--- a/test/highlight/functions.res
+++ b/test/highlight/functions.res
@@ -5,3 +5,6 @@ let inc = n => n + 1
 let uncurry = (. u, .x) => (u, x)
 //             ^ operator
 //                  ^ operator
+
+let get = async (id) => id
+//         ^ keyword


### PR DESCRIPTION
Part of ReScript v10.1 features:

- `async` could be a valid identifier (same for JS). eg `let f = (async) => async + 1`, `let async = 1`

```res
let f = (async) => async + 1
```

It is currently an error:
```
(source_file [0, 0] - [1, 0]
  (let_binding [0, 0] - [0, 28]
    (value_identifier [0, 4] - [0, 5])
    (function [0, 8] - [0, 28]
      parameters: (formal_parameters [0, 8] - [0, 15]
        (ERROR [0, 9] - [0, 14]))
      (ERROR [0, 19] - [0, 24])
      body: (unary_expression [0, 25] - [0, 28]
        argument: (number [0, 27] - [0, 28])))))
```