### PR TITLE
feat: support decorated expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -143,7 +143,10 @@ module.exports = grammar({
 
     _decorated_statement: $ => seq(
       repeat1($.decorator),
-      $.declaration,
+      choice(
+        $.declaration,
+        $.expression_statement
+      )
     ),
 
     decorator_statement: $ => seq(

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -33,6 +33,9 @@ let foo = @doesNotRaise String.make(12, ' ')
 
 let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
 
+@local
+call()
+
 ---
 
 (source_file
@@ -72,7 +75,13 @@ let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
           (value_identifier))
         (arguments
           (array)
-          (number))))))
+          (number)))))
+
+  (decorated
+    (decorator (decorator_identifier))
+    (expression_statement
+      (call_expression
+        (value_identifier) (arguments)))))
 
 ============================================
 Decorator before type `and`


### PR DESCRIPTION
See [reanalyze exampes](https://github.com/rescript-association/reanalyze/blob/388149046bf077d17639f50d4c7aea2bdd28b8b5/examples/deadcode/src/noalloc/Chess.res#L19-L20)

```res
@local
call()
```

```
(source_file [0, 0] - [2, 0]
  (ERROR [0, 0] - [1, 6]
    (decorator [0, 0] - [1, 6]
      (decorator_identifier [0, 1] - [0, 6])
      (ERROR [1, 0] - [1, 4]
        (ERROR [1, 0] - [1, 4]))
      (decorator_arguments [1, 4] - [1, 6]))))
```