### PR TITLE
Support empty record {} type declaration

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -373,7 +373,7 @@ module.exports = grammar({
 
     record_type: $ => seq(
       '{',
-      commaSep1t($.record_type_field),
+      commaSept($.record_type_field),
       '}',
     ),
 

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -81,6 +81,8 @@ type t = {
 
 type t = Mod.t = {a: int}
 
+type t = {}
+
 ---
 
 (source_file
@@ -108,7 +110,10 @@ type t = Mod.t = {a: int}
     (record_type
       (record_type_field
         (property_identifier)
-        (type_annotation (type_identifier))))))
+        (type_annotation (type_identifier)))))
+  (type_declaration
+    (type_identifier)
+    (record_type)))
 
 ===========================================
 Extensible Variant


### PR DESCRIPTION
Addresses #141 

Empty record _literals_ are not treated as records at all, but are (still) interpreted as `block`’s. Although it is incorrect semantically, I think it is OK for the purposes of `tree-sitter-rescript`.

@aspeddro, what do you think?