### PR TITLE
feat: relax rule to polyvar_declaration

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -369,7 +369,7 @@ module.exports = grammar({
           $.polyvar_identifier,
           optional($.polyvar_parameters),
         ),
-        $._type_identifier
+        $._inline_type
       )
     ),
 

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -220,6 +220,7 @@ type t = [>
 
 
 type foo<'a> = [> #Blue | #DeepBlue | #LightBlue ] as 'a
+type t<'w> = [M.t<'w>]
 
 ---
 
@@ -243,7 +244,16 @@ type foo<'a> = [> #Blue | #DeepBlue | #LightBlue ] as 'a
       (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration (polyvar_identifier))
-      (as_aliasing_type (type_identifier)))))
+      (as_aliasing_type (type_identifier))))
+
+  (type_declaration
+    (type_identifier)
+    (type_parameters (type_identifier))
+    (polyvar_type
+      (polyvar_declaration
+        (generic_type
+          (type_identifier_path (module_identifier) (type_identifier))
+          (type_arguments (type_identifier)))))))
 
 ===========================================
 Function


### PR DESCRIPTION
Here an [example](https://github.com/TheSpyder/rescript-nodejs/blob/7321edeff2e836dae5886e3a1124b1227bd8765d/src/Http2.res#L17).

```res
type subtype<'w, 'ty> = Stream.subtype<[> kind<'w, 'r>] as 'ty>
```

```
(ERROR [0, 0] - [1, 0]
  (type_identifier [0, 5] - [0, 12])
  (type_parameters [0, 12] - [0, 21]
    (type_identifier [0, 13] - [0, 15])
    (type_identifier [0, 17] - [0, 20]))
  (generic_type [0, 24] - [0, 54]
    (type_identifier_path [0, 24] - [0, 38]
      (module_identifier [0, 24] - [0, 30])
      (type_identifier [0, 31] - [0, 38]))
    (ERROR [0, 38] - [0, 46]
      (polyvar_declaration [0, 42] - [0, 46]
        (type_identifier [0, 42] - [0, 46])))
    (type_arguments [0, 46] - [0, 54]
      (type_identifier [0, 47] - [0, 49])
      (type_identifier [0, 51] - [0, 53])))
  (ERROR [0, 60] - [0, 62]))
```