### PR TITLE
fix: consecutive `and` bindings for type and module

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -189,7 +189,7 @@ module.exports = grammar({
       optional(seq(
         '=',
         field('definition', $._module_definition),
-        repeat($._module_binding_and)
+        optional($._module_binding_and)
       )),
     )),
 
@@ -271,7 +271,7 @@ module.exports = grammar({
         $._type,
         repeat($.type_constraint),
         optional(seq('=', $._type)),
-        repeat(alias($._type_declaration_and, $.type_declaration)),
+        optional(alias($._type_declaration_and, $.type_declaration)),
       )),
     ),
 

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -108,12 +108,12 @@ and bar = {bar: int}
       (type_declaration
         (decorator (decorator_identifier))
         (type_identifier)
-        (record_type (record_type_field (property_identifier) (type_annotation (type_identifier)))))
-      (type_declaration
-        (decorator (decorator_identifier))
-        (decorator (decorator_identifier))
-        (type_identifier)
-        (record_type (record_type_field (property_identifier) (type_annotation (type_identifier))))))))
+        (record_type (record_type_field (property_identifier) (type_annotation (type_identifier))))
+        (type_declaration
+          (decorator (decorator_identifier))
+          (decorator (decorator_identifier))
+          (type_identifier)
+          (record_type (record_type_field (property_identifier) (type_annotation (type_identifier)))))))))
 
 ============================================
 Decorator with type


### PR DESCRIPTION
Related: #171 

```res
module MainParser = {
  type rec tree = {
    rootNode: syntaxNode,
    copy: unit => tree,
    getLanguage: unit => language,
  }
  and syntaxNode = {
    id: int,
    text: string,
    @as("type") type_: string,
    tree: tree,
  }
  and language = {load: (. string) => Js.Promise.t<language>}
  and point = {row: int, column: int}
  and input =
    String(string) | Input({startIndex: int, startPoint: point, endIndex: int})
  and t = {
    init: (. unit) => Js.Promise.t<unit>,
    setLanguage: (. language) => unit,
    parse: (. string) => tree,
    language: language,
  }

  @send external toString: syntaxNode => string = "toString"

  let parse = (t, input) =>
    switch input {
    | String(s) => t.parse(. s)
    | _ => t.parse(. "Js.log")
    }
}
```

```
yarn run v1.22.19
$ /home/pedro/Desktop/projects/tree-sitter-rescript/node_modules/.bin/tree-sitter parse ../../test-filetypes/rescript_print.res
(source_file [0, 0] - [31, 0]
  (module_declaration [0, 0] - [30, 1]
    name: (module_identifier [0, 7] - [0, 17])
    definition: (block [0, 20] - [30, 1]
      (ERROR [1, 2] - [23, 60]
        (type_identifier [1, 11] - [1, 15])
        (record_type [1, 18] - [5, 3]
          (record_type_field [2, 4] - [2, 24]
            (property_identifier [2, 4] - [2, 12])
            (type_annotation [2, 12] - [2, 24]
              (type_identifier [2, 14] - [2, 24])))
          (record_type_field [3, 4] - [3, 22]
            (property_identifier [3, 4] - [3, 8])
            (type_annotation [3, 8] - [3, 22]
              (function_type [3, 10] - [3, 22]
                (function_type_parameters [3, 10] - [3, 14]
                  (unit_type [3, 10] - [3, 14]))
                (type_identifier [3, 18] - [3, 22]))))
          (record_type_field [4, 4] - [4, 33]
            (property_identifier [4, 4] - [4, 15])
            (type_annotation [4, 15] - [4, 33]
              (function_type [4, 17] - [4, 33]
                (function_type_parameters [4, 17] - [4, 21]
                  (unit_type [4, 17] - [4, 21]))
                (type_identifier [4, 25] - [4, 33])))))
        (type_declaration [6, 2] - [13, 37]
          (type_identifier [6, 6] - [6, 16])
          (record_type [6, 19] - [11, 3]
            (record_type_field [7, 4] - [7, 11]
              (property_identifier [7, 4] - [7, 6])
              (type_annotation [7, 6] - [7, 11]
                (type_identifier [7, 8] - [7, 11])))
            (record_type_field [8, 4] - [8, 16]
              (property_identifier [8, 4] - [8, 8])
              (type_annotation [8, 8] - [8, 16]
                (type_identifier [8, 10] - [8, 16])))
            (record_type_field [9, 4] - [9, 29]
              (decorator [9, 4] - [9, 15]
                (decorator_identifier [9, 5] - [9, 7])
                (decorator_arguments [9, 7] - [9, 15]
                  (string [9, 8] - [9, 14]
                    (string_fragment [9, 9] - [9, 13]))))
              (property_identifier [9, 16] - [9, 21])
              (type_annotation [9, 21] - [9, 29]
                (type_identifier [9, 23] - [9, 29])))
            (record_type_field [10, 4] - [10, 14]
              (property_identifier [10, 4] - [10, 8])
              (type_annotation [10, 8] - [10, 14]
                (type_identifier [10, 10] - [10, 14]))))
          (type_declaration [12, 2] - [12, 61]
            (type_identifier [12, 6] - [12, 14])
            (record_type [12, 17] - [12, 61]
              (record_type_field [12, 18] - [12, 60]
                (property_identifier [12, 18] - [12, 22])
                (type_annotation [12, 22] - [12, 60]
                  (function_type [12, 24] - [12, 60]
                    (function_type_parameters [12, 24] - [12, 34]
                      (parameter [12, 25] - [12, 33]
                        (uncurry [12, 25] - [12, 26])
                        (type_identifier [12, 27] - [12, 33])))
                    (generic_type [12, 38] - [12, 60]
                      (type_identifier_path [12, 38] - [12, 50]
                        (module_identifier_path [12, 38] - [12, 48]
                          (module_identifier [12, 38] - [12, 40])
                          (module_identifier [12, 41] - [12, 48]))
                        (type_identifier [12, 49] - [12, 50]))
                      (type_arguments [12, 50] - [12, 60]
                        (type_identifier [12, 51] - [12, 59]))))))))
          (type_declaration [13, 2] - [13, 37]
            (type_identifier [13, 6] - [13, 11])
            (record_type [13, 14] - [13, 37]
              (record_type_field [13, 15] - [13, 23]
                (property_identifier [13, 15] - [13, 18])
                (type_annotation [13, 18] - [13, 23]
                  (type_identifier [13, 20] - [13, 23])))
              (record_type_field [13, 25] - [13, 36]
                (property_identifier [13, 25] - [13, 31])
                (type_annotation [13, 31] - [13, 36]
                  (type_identifier [13, 33] - [13, 36]))))))
        (type_declaration [14, 2] - [15, 79]
          (type_identifier [14, 6] - [14, 11])
          (variant_type [15, 4] - [15, 79]
            (variant_declaration [15, 4] - [15, 18]
              (variant_identifier [15, 4] - [15, 10])
              (variant_parameters [15, 10] - [15, 18]
                (type_identifier [15, 11] - [15, 17])))
            (variant_declaration [15, 21] - [15, 79]
              (variant_identifier [15, 21] - [15, 26])
              (variant_parameters [15, 26] - [15, 79]
                (record_type [15, 27] - [15, 78]
                  (record_type_field [15, 28] - [15, 43]
                    (property_identifier [15, 28] - [15, 38])
                    (type_annotation [15, 38] - [15, 43]
                      (type_identifier [15, 40] - [15, 43])))
                  (record_type_field [15, 45] - [15, 62]
                    (property_identifier [15, 45] - [15, 55])
                    (type_annotation [15, 55] - [15, 62]
                      (type_identifier [15, 57] - [15, 62])))
                  (record_type_field [15, 64] - [15, 77]
                    (property_identifier [15, 64] - [15, 72])
                    (type_annotation [15, 72] - [15, 77]
                      (type_identifier [15, 74] - [15, 77]))))))))
        (type_identifier [16, 6] - [16, 7])
        (ERROR [16, 10] - [23, 19]
          (record_type [16, 10] - [21, 3]
            (record_type_field [17, 4] - [17, 40]
              (property_identifier [17, 4] - [17, 8])
              (type_annotation [17, 8] - [17, 40]
                (function_type [17, 10] - [17, 40]
                  (function_type_parameters [17, 10] - [17, 18]
                    (parameter [17, 11] - [17, 17]
                      (uncurry [17, 11] - [17, 12])
                      (unit_type [17, 13] - [17, 17])))
                  (generic_type [17, 22] - [17, 40]
                    (type_identifier_path [17, 22] - [17, 34]
                      (module_identifier_path [17, 22] - [17, 32]
                        (module_identifier [17, 22] - [17, 24])
                        (module_identifier [17, 25] - [17, 32]))
                      (type_identifier [17, 33] - [17, 34]))
                    (type_arguments [17, 34] - [17, 40]
                      (unit_type [17, 35] - [17, 39]))))))
            (record_type_field [18, 4] - [18, 37]
              (property_identifier [18, 4] - [18, 15])
              (type_annotation [18, 15] - [18, 37]
                (function_type [18, 17] - [18, 37]
                  (function_type_parameters [18, 17] - [18, 29]
                    (parameter [18, 18] - [18, 28]
                      (uncurry [18, 18] - [18, 19])
                      (type_identifier [18, 20] - [18, 28])))
                  (unit_type [18, 33] - [18, 37]))))
            (record_type_field [19, 4] - [19, 29]
              (property_identifier [19, 4] - [19, 9])
              (type_annotation [19, 9] - [19, 29]
                (function_type [19, 11] - [19, 29]
                  (function_type_parameters [19, 11] - [19, 21]
                    (parameter [19, 12] - [19, 20]
                      (uncurry [19, 12] - [19, 13])
                      (type_identifier [19, 14] - [19, 20])))
                  (type_identifier [19, 25] - [19, 29]))))
            (record_type_field [20, 4] - [20, 22]
              (property_identifier [20, 4] - [20, 12])
              (type_annotation [20, 12] - [20, 22]
                (type_identifier [20, 14] - [20, 22]))))
          (decorator [23, 2] - [23, 7]
            (decorator_identifier [23, 3] - [23, 7])))
        (variant_type [23, 19] - [23, 47]
          (variant_declaration [23, 19] - [23, 47]
            (variant_identifier [23, 19] - [23, 25])
            (type_annotation [23, 25] - [23, 47]
              (function_type [23, 27] - [23, 47]
                (function_type_parameters [23, 27] - [23, 37]
                  (type_identifier [23, 27] - [23, 37]))
                (type_identifier [23, 41] - [23, 47])))))
        (ERROR [23, 50] - [23, 53])
        (module_identifier [23, 53] - [23, 59]))
      (let_binding [25, 2] - [29, 5]
        (value_identifier [25, 6] - [25, 11])
        (function [25, 14] - [29, 5]
          parameters: (formal_parameters [25, 14] - [25, 24]
            (parameter [25, 15] - [25, 16]
              (value_identifier [25, 15] - [25, 16]))
            (parameter [25, 18] - [25, 23]
              (value_identifier [25, 18] - [25, 23])))
          body: (switch_expression [26, 4] - [29, 5]
            (value_identifier [26, 11] - [26, 16])
            (switch_match [27, 4] - [27, 31]
              (variant_pattern [27, 6] - [27, 15]
                (variant_identifier [27, 6] - [27, 12])
                (formal_parameters [27, 12] - [27, 15]
                  (value_identifier [27, 13] - [27, 14])))
              (expression_statement [27, 19] - [27, 31]
                (call_expression [27, 19] - [27, 31]
                  function: (member_expression [27, 19] - [27, 26]
                    record: (value_identifier [27, 19] - [27, 20])
                    property: (property_identifier [27, 21] - [27, 26]))
                  arguments: (arguments [27, 26] - [27, 31]
                    (uncurry [27, 27] - [27, 28])
                    (value_identifier [27, 29] - [27, 30])))))
            (switch_match [28, 4] - [28, 30]
              (value_identifier [28, 6] - [28, 7])
              (expression_statement [28, 11] - [28, 30]
                (call_expression [28, 11] - [28, 30]
                  function: (member_expression [28, 11] - [28, 18]
                    record: (value_identifier [28, 11] - [28, 12])
                    property: (property_identifier [28, 13] - [28, 18]))
                  arguments: (arguments [28, 18] - [28, 30]
                    (uncurry [28, 19] - [28, 20])
                    (string [28, 20] - [28, 29]
                      (string_fragment [28, 22] - [28, 28]))))))))))))
../../test-filetypes/rescript_print.res	0 ms	(ERROR [1, 2] - [23, 60])
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```
yarn run v1.22.19
$ /home/pedro/Desktop/projects/tree-sitter-rescript/node_modules/.bin/tree-sitter parse ../../test-filetypes/rescript_print.res
(source_file [0, 0] - [31, 0]
  (module_declaration [0, 0] - [30, 1]
    name: (module_identifier [0, 7] - [0, 17])
    definition: (block [0, 20] - [30, 1]
      (type_declaration [1, 2] - [21, 3]
        (type_identifier [1, 11] - [1, 15])
        (record_type [1, 18] - [5, 3]
          (record_type_field [2, 4] - [2, 24]
            (property_identifier [2, 4] - [2, 12])
            (type_annotation [2, 12] - [2, 24]
              (type_identifier [2, 14] - [2, 24])))
          (record_type_field [3, 4] - [3, 22]
            (property_identifier [3, 4] - [3, 8])
            (type_annotation [3, 8] - [3, 22]
              (function_type [3, 10] - [3, 22]
                (function_type_parameters [3, 10] - [3, 14]
                  (unit_type [3, 10] - [3, 14]))
                (type_identifier [3, 18] - [3, 22]))))
          (record_type_field [4, 4] - [4, 33]
            (property_identifier [4, 4] - [4, 15])
            (type_annotation [4, 15] - [4, 33]
              (function_type [4, 17] - [4, 33]
                (function_type_parameters [4, 17] - [4, 21]
                  (unit_type [4, 17] - [4, 21]))
                (type_identifier [4, 25] - [4, 33])))))
        (type_declaration [6, 2] - [21, 3]
          (type_identifier [6, 6] - [6, 16])
          (record_type [6, 19] - [11, 3]
            (record_type_field [7, 4] - [7, 11]
              (property_identifier [7, 4] - [7, 6])
              (type_annotation [7, 6] - [7, 11]
                (type_identifier [7, 8] - [7, 11])))
            (record_type_field [8, 4] - [8, 16]
              (property_identifier [8, 4] - [8, 8])
              (type_annotation [8, 8] - [8, 16]
                (type_identifier [8, 10] - [8, 16])))
            (record_type_field [9, 4] - [9, 29]
              (decorator [9, 4] - [9, 15]
                (decorator_identifier [9, 5] - [9, 7])
                (decorator_arguments [9, 7] - [9, 15]
                  (string [9, 8] - [9, 14]
                    (string_fragment [9, 9] - [9, 13]))))
              (property_identifier [9, 16] - [9, 21])
              (type_annotation [9, 21] - [9, 29]
                (type_identifier [9, 23] - [9, 29])))
            (record_type_field [10, 4] - [10, 14]
              (property_identifier [10, 4] - [10, 8])
              (type_annotation [10, 8] - [10, 14]
                (type_identifier [10, 10] - [10, 14]))))
          (type_declaration [12, 2] - [21, 3]
            (type_identifier [12, 6] - [12, 14])
            (record_type [12, 17] - [12, 61]
              (record_type_field [12, 18] - [12, 60]
                (property_identifier [12, 18] - [12, 22])
                (type_annotation [12, 22] - [12, 60]
                  (function_type [12, 24] - [12, 60]
                    (function_type_parameters [12, 24] - [12, 34]
                      (parameter [12, 25] - [12, 33]
                        (uncurry [12, 25] - [12, 26])
                        (type_identifier [12, 27] - [12, 33])))
                    (generic_type [12, 38] - [12, 60]
                      (type_identifier_path [12, 38] - [12, 50]
                        (module_identifier_path [12, 38] - [12, 48]
                          (module_identifier [12, 38] - [12, 40])
                          (module_identifier [12, 41] - [12, 48]))
                        (type_identifier [12, 49] - [12, 50]))
                      (type_arguments [12, 50] - [12, 60]
                        (type_identifier [12, 51] - [12, 59])))))))
            (type_declaration [13, 2] - [21, 3]
              (type_identifier [13, 6] - [13, 11])
              (record_type [13, 14] - [13, 37]
                (record_type_field [13, 15] - [13, 23]
                  (property_identifier [13, 15] - [13, 18])
                  (type_annotation [13, 18] - [13, 23]
                    (type_identifier [13, 20] - [13, 23])))
                (record_type_field [13, 25] - [13, 36]
                  (property_identifier [13, 25] - [13, 31])
                  (type_annotation [13, 31] - [13, 36]
                    (type_identifier [13, 33] - [13, 36]))))
              (type_declaration [14, 2] - [21, 3]
                (type_identifier [14, 6] - [14, 11])
                (variant_type [15, 4] - [15, 79]
                  (variant_declaration [15, 4] - [15, 18]
                    (variant_identifier [15, 4] - [15, 10])
                    (variant_parameters [15, 10] - [15, 18]
                      (type_identifier [15, 11] - [15, 17])))
                  (variant_declaration [15, 21] - [15, 79]
                    (variant_identifier [15, 21] - [15, 26])
                    (variant_parameters [15, 26] - [15, 79]
                      (record_type [15, 27] - [15, 78]
                        (record_type_field [15, 28] - [15, 43]
                          (property_identifier [15, 28] - [15, 38])
                          (type_annotation [15, 38] - [15, 43]
                            (type_identifier [15, 40] - [15, 43])))
                        (record_type_field [15, 45] - [15, 62]
                          (property_identifier [15, 45] - [15, 55])
                          (type_annotation [15, 55] - [15, 62]
                            (type_identifier [15, 57] - [15, 62])))
                        (record_type_field [15, 64] - [15, 77]
                          (property_identifier [15, 64] - [15, 72])
                          (type_annotation [15, 72] - [15, 77]
                            (type_identifier [15, 74] - [15, 77])))))))
                (type_declaration [16, 2] - [21, 3]
                  (type_identifier [16, 6] - [16, 7])
                  (record_type [16, 10] - [21, 3]
                    (record_type_field [17, 4] - [17, 40]
                      (property_identifier [17, 4] - [17, 8])
                      (type_annotation [17, 8] - [17, 40]
                        (function_type [17, 10] - [17, 40]
                          (function_type_parameters [17, 10] - [17, 18]
                            (parameter [17, 11] - [17, 17]
                              (uncurry [17, 11] - [17, 12])
                              (unit_type [17, 13] - [17, 17])))
                          (generic_type [17, 22] - [17, 40]
                            (type_identifier_path [17, 22] - [17, 34]
                              (module_identifier_path [17, 22] - [17, 32]
                                (module_identifier [17, 22] - [17, 24])
                                (module_identifier [17, 25] - [17, 32]))
                              (type_identifier [17, 33] - [17, 34]))
                            (type_arguments [17, 34] - [17, 40]
                              (unit_type [17, 35] - [17, 39]))))))
                    (record_type_field [18, 4] - [18, 37]
                      (property_identifier [18, 4] - [18, 15])
                      (type_annotation [18, 15] - [18, 37]
                        (function_type [18, 17] - [18, 37]
                          (function_type_parameters [18, 17] - [18, 29]
                            (parameter [18, 18] - [18, 28]
                              (uncurry [18, 18] - [18, 19])
                              (type_identifier [18, 20] - [18, 28])))
                          (unit_type [18, 33] - [18, 37]))))
                    (record_type_field [19, 4] - [19, 29]
                      (property_identifier [19, 4] - [19, 9])
                      (type_annotation [19, 9] - [19, 29]
                        (function_type [19, 11] - [19, 29]
                          (function_type_parameters [19, 11] - [19, 21]
                            (parameter [19, 12] - [19, 20]
                              (uncurry [19, 12] - [19, 13])
                              (type_identifier [19, 14] - [19, 20])))
                          (type_identifier [19, 25] - [19, 29]))))
                    (record_type_field [20, 4] - [20, 22]
                      (property_identifier [20, 4] - [20, 12])
                      (type_annotation [20, 12] - [20, 22]
                        (type_identifier [20, 14] - [20, 22]))))))))))
      (decorated [23, 2] - [23, 60]
        (decorator [23, 2] - [23, 7]
          (decorator_identifier [23, 3] - [23, 7]))
        (external_declaration [23, 8] - [23, 60]
          (value_identifier [23, 17] - [23, 25])
          (type_annotation [23, 25] - [23, 47]
            (function_type [23, 27] - [23, 47]
              (function_type_parameters [23, 27] - [23, 37]
                (type_identifier [23, 27] - [23, 37]))
              (type_identifier [23, 41] - [23, 47])))
          (string [23, 49] - [23, 60]
            (string_fragment [23, 51] - [23, 59]))))
      (let_binding [25, 2] - [29, 5]
        (value_identifier [25, 6] - [25, 11])
        (function [25, 14] - [29, 5]
          parameters: (formal_parameters [25, 14] - [25, 24]
            (parameter [25, 15] - [25, 16]
              (value_identifier [25, 15] - [25, 16]))
            (parameter [25, 18] - [25, 23]
              (value_identifier [25, 18] - [25, 23])))
          body: (switch_expression [26, 4] - [29, 5]
            (value_identifier [26, 11] - [26, 16])
            (switch_match [27, 4] - [27, 31]
              (variant_pattern [27, 6] - [27, 15]
                (variant_identifier [27, 6] - [27, 12])
                (formal_parameters [27, 12] - [27, 15]
                  (value_identifier [27, 13] - [27, 14])))
              (expression_statement [27, 19] - [27, 31]
                (call_expression [27, 19] - [27, 31]
                  function: (member_expression [27, 19] - [27, 26]
                    record: (value_identifier [27, 19] - [27, 20])
                    property: (property_identifier [27, 21] - [27, 26]))
                  arguments: (arguments [27, 26] - [27, 31]
                    (uncurry [27, 27] - [27, 28])
                    (value_identifier [27, 29] - [27, 30])))))
            (switch_match [28, 4] - [28, 30]
              (value_identifier [28, 6] - [28, 7])
              (expression_statement [28, 11] - [28, 30]
                (call_expression [28, 11] - [28, 30]
                  function: (member_expression [28, 11] - [28, 18]
                    record: (value_identifier [28, 11] - [28, 12])
                    property: (property_identifier [28, 13] - [28, 18]))
                  arguments: (arguments [28, 18] - [28, 30]
                    (uncurry [28, 19] - [28, 20])
                    (string [28, 20] - [28, 29]
                      (string_fragment [28, 22] - [28, 28]))))))))))))
Done in 0.47s.

```