### PR TITLE
Allow blocks on LHS of pipe expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -743,7 +743,10 @@ module.exports = grammar({
     )),
 
     pipe_expression: $ => prec.left(seq(
-      $.primary_expression,
+      choice(
+        $.primary_expression,
+        $.block,
+      ),
       choice('->', '|>'),
       choice(
         $.value_identifier,

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -196,6 +196,8 @@ foo->{
   baz
 }
 
+{foo}->print()
+
 ---
 
 (source_file
@@ -243,7 +245,13 @@ foo->{
       (value_identifier)
       (block
         (open_statement (module_identifier))
-        (expression_statement (value_identifier))))))
+        (expression_statement (value_identifier)))))
+  (expression_statement
+    (call_expression
+      (pipe_expression
+        (block (expression_statement (value_identifier)))
+        (value_identifier))
+      (arguments))))
 
 ===========================================
 Record


### PR DESCRIPTION
Close https://github.com/nkrkv/tree-sitter-rescript/issues/178

I’m tempted to generalize pipe expression as seen in #176 and #177. But to me, they are too wide, producing extraneous grammar conflicts for constructs not legal actually in ReScript.

So, as an alternative proposal, can we have a nailed-down addition to fix the bug, but not go too wide?

/cc @aspeddro 