### PR TITLE
Allow ticks in more identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1325,7 +1325,7 @@ module.exports = grammar({
     polyvar_identifier: $ => seq(
       '#',
       choice(
-        /[a-zA-Z0-9_]+/,
+        /[a-zA-Z0-9_']+/,
         seq(
           optional('\\'),
           alias($.string, $.polyvar_string),
@@ -1334,7 +1334,7 @@ module.exports = grammar({
     ),
 
     type_identifier: $ => choice(
-      /[a-z_'][a-zA-Z0-9_]*/,
+      /[a-z_'][a-zA-Z0-9_']*/,
       $._escape_identifier,
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1320,7 +1320,7 @@ module.exports = grammar({
       $.block,
     ),
 
-    variant_identifier: $ => /[A-Z][a-zA-Z0-9_]*/,
+    variant_identifier: $ => /[A-Z][a-zA-Z0-9_']*/,
 
     polyvar_identifier: $ => seq(
       '#',
@@ -1346,7 +1346,7 @@ module.exports = grammar({
 
     _escape_identifier: $ => token(seq('\\"', /[^"]+/ , '"')),
 
-    module_identifier: $ => /[A-Z][a-zA-Z0-9_]*/,
+    module_identifier: $ => /[A-Z][a-zA-Z0-9_']*/,
 
     decorator_identifier: $ => /[a-zA-Z0-9_\.]+/,
 

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -268,6 +268,7 @@ Alias
 ===========================================
 
 module Q = Foo.Bar.Qux
+module Foo' = Foo
 
 ---
 
@@ -278,7 +279,10 @@ module Q = Foo.Bar.Qux
       (module_identifier_path
         (module_identifier)
         (module_identifier))
-      (module_identifier))))
+      (module_identifier)))
+  (module_declaration
+    (module_identifier)
+    (module_identifier)))
 
 ===========================================
 Recursive

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -3,11 +3,13 @@ Opaque
 ===========================================
 
 type t
+type t'
 type \"type"
 
 ---
 
 (source_file
+ (type_declaration (type_identifier))
  (type_declaration (type_identifier))
  (type_declaration (type_identifier)))
 
@@ -212,6 +214,7 @@ Polyvar
 
 type t = [>
   | #AAA
+  | #AAA'
   | #bbb(anotherType)
   | #"cc-cc"
   | #\"cc-cc"
@@ -230,6 +233,7 @@ type t<'w> = [M.t<'w>]
   (type_declaration
     (type_identifier)
     (polyvar_type
+      (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration
         (polyvar_identifier) (polyvar_parameters (type_identifier)))

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -151,6 +151,7 @@ Variant
 
 type t =
   | A
+  | A'
   | @live("t.D") D
   | B(anotherType)
   | C({foo: int, bar: string})
@@ -163,6 +164,7 @@ type t =
   (type_declaration
     (type_identifier)
     (variant_type
+      (variant_declaration (variant_identifier))
       (variant_declaration (variant_identifier))
       (variant_declaration
         (decorator (decorator_identifier) (decorator_arguments (string (string_fragment))))


### PR DESCRIPTION
Trailing and infix ticks are allowed in the following identifiers:

- Modules (fixes #180)
- Variants
- Polyvars
- Types