### PR TITLE
fix: support aliasing type for generic-type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -424,10 +424,11 @@ module.exports = grammar({
 
     ),
 
-    generic_type: $ => seq(
+    generic_type: $ => prec.left(seq(
       $._type_identifier,
-      $.type_arguments
-    ),
+      $.type_arguments,
+      optional($.as_aliasing_type)
+    )),
 
     type_arguments: $ => seq(
       '<',

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -349,6 +349,7 @@ Generic
 
 type t<'a, 'b> = (array<'a>, array<'b>)
 type t = result<(), string>
+type t<'a> = generic<'a> as 's
 
 ---
 
@@ -365,7 +366,15 @@ type t = result<(), string>
       (type_identifier)
       (type_arguments
         (unit)
-        (type_identifier)))))
+        (type_identifier))))
+
+  (type_declaration
+    (type_identifier)
+    (type_parameters (type_identifier))
+    (generic_type
+      (type_identifier)
+      (type_arguments (type_identifier))
+      (as_aliasing_type (type_identifier)))))
 
 ===========================================
 Recursive


### PR DESCRIPTION
Example from [rescript-nodejs](https://github.com/TheSpyder/rescript-nodejs/blob/f20b20744cf66440b4f4cc2983838ebaff8995bd/src/Fs.res#L430)

```res
@send
external onReady: (
  subtype<'w, [> kind<'w>]> as 'stream,
  @as("ready") _,
  @uncurry (unit => unit),
) => 'stream = "on"
```

```
yarn run v1.22.19
$ /home/pedro/Desktop/projects/tree-sitter-rescript/node_modules/.bin/tree-sitter parse ../../test-filetypes/rescript_print.res
(source_file [0, 0] - [6, 0]
  (decorated [0, 0] - [5, 19]
    (decorator [0, 0] - [0, 5]
      (decorator_identifier [0, 1] - [0, 5]))
    (external_declaration [1, 0] - [5, 19]
      (value_identifier [1, 9] - [1, 16])
      (type_annotation [1, 16] - [5, 12]
        (function_type [1, 18] - [5, 12]
          (function_type_parameters [1, 18] - [5, 1]
            (parameter [2, 2] - [2, 27]
              (generic_type [2, 2] - [2, 27]
                (type_identifier [2, 2] - [2, 9])
                (type_arguments [2, 9] - [2, 27]
                  (type_identifier [2, 10] - [2, 12])
                  (polyvar_type [2, 14] - [2, 26]
                    (polyvar_declaration [2, 17] - [2, 25]
                      (generic_type [2, 17] - [2, 25]
                        (type_identifier [2, 17] - [2, 21])
                        (type_arguments [2, 21] - [2, 25]
                          (type_identifier [2, 22] - [2, 24]))))))))
            (ERROR [2, 28] - [2, 38]
              (ERROR [2, 32] - [2, 38]))
            (parameter [3, 2] - [3, 16]
              (decorator [3, 2] - [3, 14]
                (decorator_identifier [3, 3] - [3, 5])
                (decorator_arguments [3, 5] - [3, 14]
                  (string [3, 6] - [3, 13]
                    (string_fragment [3, 7] - [3, 12]))))
              (type_identifier [3, 15] - [3, 16]))
            (parameter [4, 2] - [4, 25]
              (decorator [4, 2] - [4, 10]
                (decorator_identifier [4, 3] - [4, 10]))
              (tuple_type [4, 11] - [4, 25]
                (function_type [4, 12] - [4, 24]
                  (function_type_parameters [4, 12] - [4, 16]
                    (unit_type [4, 12] - [4, 16]))
                  (unit_type [4, 20] - [4, 24])))))
          (type_identifier [5, 5] - [5, 12])))
      (string [5, 14] - [5, 19]
        (string_fragment [5, 16] - [5, 18])))))
../../test-filetypes/rescript_print.res	0 ms	(ERROR [2, 28] - [2, 38])
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```