### PR TITLE
fix: type constraint

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -266,7 +266,6 @@ module.exports = grammar({
       choice($.type_identifier, $.type_identifier_path),
       optional($.type_parameters),
       optional(seq(
-        optional($.type_parameters),
         optional(seq('=', $._type)),
         optional(seq(
           choice('=', '+='),

--- a/grammar.js
+++ b/grammar.js
@@ -263,26 +263,18 @@ module.exports = grammar({
     ),
 
     _type_declaration: $ => seq(
-      choice(
-        seq(
-          $.type_identifier,
-          optional($.type_parameters),
-          optional(seq('=', $._type)),
-          optional(seq(
-            '=',
-            optional('private'),
-            $._type,
-          )),
-          repeat($.type_constraint),
-        ),
-        seq(
-          choice($.type_identifier, $.type_identifier_path),
-          optional($.type_parameters),
-          '+=',
+      choice($.type_identifier, $.type_identifier_path),
+      optional($.type_parameters),
+      optional(seq(
+        optional($.type_parameters),
+        optional(seq('=', $._type)),
+        optional(seq(
+          choice('=', '+='),
           optional('private'),
-          $.variant_type,
-        )
-      ),
+          $._type,
+        )),
+        repeat($.type_constraint),
+      )),
       optional(alias($._type_declaration_and, $.type_declaration))
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -259,20 +259,31 @@ module.exports = grammar({
       optional('export'),
       'type',
       optional('rec'),
-      $._type_declaration,
+      $._type_declaration
     ),
 
     _type_declaration: $ => seq(
-      choice($.type_identifier, $.type_identifier_path),
-      optional($.type_parameters),
-      optional(seq(
-        choice('=', '+='),
-        optional('private'),
-        $._type,
-        repeat($.type_constraint),
-        optional(seq('=', $._type)),
-        optional(alias($._type_declaration_and, $.type_declaration)),
-      )),
+      choice(
+        seq(
+          $.type_identifier,
+          optional($.type_parameters),
+          optional(seq('=', $._type)),
+          optional(seq(
+            '=',
+            optional('private'),
+            $._type,
+          )),
+          repeat($.type_constraint),
+        ),
+        seq(
+          choice($.type_identifier, $.type_identifier_path),
+          optional($.type_parameters),
+          '+=',
+          optional('private'),
+          $.variant_type,
+        )
+      ),
+      optional(alias($._type_declaration_and, $.type_declaration))
     ),
 
     _type_declaration_and: $ => seq(

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -530,6 +530,7 @@ Type constraint
 
 type t<'a> = 'a constraint 'a = int
 type decorator<'a, 'b> = 'a => 'b constraint 'a = int constraint 'b = _ => _
+type t<'a> constraint 'a = t
 
 ---
 
@@ -553,4 +554,11 @@ type decorator<'a, 'b> = 'a => 'b constraint 'a = int constraint 'b = _ => _
       (type_identifier)
       (function_type
         (function_type_parameters (type_identifier))
-        (type_identifier)))))
+        (type_identifier))))
+
+  (type_declaration
+    (type_identifier)
+    (type_parameters (type_identifier))
+    (type_constraint
+      (type_identifier)
+      (type_identifier))))

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -5,13 +5,16 @@ Opaque
 type t
 type t'
 type \"type"
+type t and b
 
 ---
 
 (source_file
  (type_declaration (type_identifier))
  (type_declaration (type_identifier))
- (type_declaration (type_identifier)))
+ (type_declaration (type_identifier))
+ (type_declaration (type_identifier)
+  (type_declaration (type_identifier))))
 
 ===========================================
 Export


### PR DESCRIPTION
Example from [rescript-nodejs](https://github.com/TheSpyder/rescript-nodejs/blob/46f8e255d0375a6db9f361200189dd254c9b3953/src/Net.res#L306)

```res
type subtype<'ty> constraint 'ty = [> kind]
```

```
yarn run v1.22.19
$ /home/pedro/Desktop/projects/tree-sitter-rescript/node_modules/.bin/tree-sitter parse ../../test-filetypes/rescript_print.res
(source_file [0, 0] - [1, 0]
  (ERROR [0, 0] - [1, 0]
    (type_declaration [0, 0] - [0, 17]
      (type_identifier [0, 5] - [0, 12])
      (type_parameters [0, 12] - [0, 17]
        (type_identifier [0, 13] - [0, 16])))))
../../test-filetypes/rescript_print.res	0 ms	(ERROR [0, 0] - [1, 0])
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```