### PR TITLE
Support decorators (take 3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ wild_github_repos := rescript-lang/rescript-react \
 										 rescript-association/rescript-lang.org \
 										 tinymce/rescript-webapi \
 										 cca-io/rescript-material-ui \
-										 rescript-association/reanalyze
+										 rescript-association/reanalyze \
+										 TheSpyder/rescript-nodejs.git
 
 wild_sandboxes := $(patsubst %,test_wild/%,$(wild_github_repos))
 

--- a/grammar.js
+++ b/grammar.js
@@ -106,7 +106,8 @@ module.exports = grammar({
     [$.variant_declaration],
     [$.unit, $._function_type_parameter_list],
     [$.functor_parameter, $.module_primary_expression, $.module_identifier_path],
-    [$._reserved_identifier, $.function]
+    [$._reserved_identifier, $.function],
+    [$.polyvar_type]
   ],
 
   rules: {
@@ -364,6 +365,7 @@ module.exports = grammar({
     ),
 
     polyvar_type: $ => prec.left(seq(
+      repeat($.decorator),
       choice('[', '[>', '[<',),
       optional('|'),
       barSep1($.polyvar_declaration),
@@ -374,7 +376,7 @@ module.exports = grammar({
     polyvar_declaration: $ => prec.right(
       choice(
         seq(
-          optional($.decorator),
+          repeat($.decorator),
           $.polyvar_identifier,
           optional($.polyvar_parameters),
         ),
@@ -629,19 +631,27 @@ module.exports = grammar({
 
     tuple: $ => seq(
       '(',
-      commaSep2t($.expression),
+      commaSep2t(
+        seq(repeat($.decorator), $.expression)
+      ),
       ')',
     ),
 
     array: $ => seq(
       '[',
-      commaSept($.expression),
+      commaSept(
+        seq(repeat($.decorator), $.expression)
+      ),
       ']'
     ),
 
     list: $ => seq(
       'list{',
-      optional(commaSep1t($._list_element)),
+      optional(
+        commaSep1t(
+          seq(repeat($.decorator), $._list_element)
+        )
+      ),
       '}'
     ),
 
@@ -799,6 +809,7 @@ module.exports = grammar({
         seq(
           '=',
           optional('?'),
+          repeat($.decorator),
           field('value', $.expression),
           optional(field('type', $.type_annotation)),
         ),
@@ -931,19 +942,28 @@ module.exports = grammar({
 
     tuple_pattern: $ => seq(
       '(',
-      commaSep2t(alias($._pattern, $.tuple_item_pattern)),
+      commaSep2t(
+        alias(
+          seq(repeat($.decorator), $._pattern),
+          $.tuple_item_pattern
+        )
+      ),
       ')',
     ),
 
     array_pattern: $ => seq(
       '[',
-      optional(commaSep1t($._collection_element_pattern)),
+      optional(commaSep1t(
+        seq(repeat($.decorator), $._collection_element_pattern)
+      )),
       ']',
     ),
 
     list_pattern: $ => seq(
       'list{',
-      optional(commaSep1t($._collection_element_pattern)),
+      optional(commaSep1t(
+        seq(repeat($.decorator), $._collection_element_pattern)
+      )),
       '}',
     ),
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -101,6 +101,7 @@ blocky(
   ~third={3},
 )
 f(raise)
+call(~a=@decorator 1)
 
 ---
 
@@ -172,7 +173,16 @@ f(raise)
     (call_expression
       function: (value_identifier)
       arguments: (arguments
-        (value_identifier)))))
+        (value_identifier))))
+
+  (expression_statement
+    (call_expression
+      function: (value_identifier)
+      arguments: (arguments
+        (labeled_argument
+          label: (value_identifier)
+          (decorator (decorator_identifier))
+          value: (number))))))
 
 ===========================================
 Pipe

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -88,6 +88,7 @@ Array destructuring
 
 let [bar, baz] = foo
 let [bar, baz, _] = foo
+let [@decorator bar, _] = foo
 
 ---
 
@@ -103,6 +104,13 @@ let [bar, baz, _] = foo
       (value_identifier)
       (value_identifier)
       (value_identifier))
+    (value_identifier))
+
+  (let_binding
+    (array_pattern
+      (decorator (decorator_identifier))
+      (value_identifier)
+      (value_identifier))
     (value_identifier)))
 
 ============================================
@@ -110,12 +118,20 @@ List destructuring
 ============================================
 
 let list{head, ...tail} = foo
+let list{@decorator head, ..._} = foo
 
 ---
 
 (source_file
   (let_binding
     (list_pattern
+      (value_identifier)
+      (spread_pattern (value_identifier)))
+    (value_identifier))
+
+  (let_binding
+    (list_pattern
+      (decorator (decorator_identifier))
       (value_identifier)
       (spread_pattern (value_identifier)))
     (value_identifier)))

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -227,7 +227,7 @@ type t = [>
   ]
 
 
-type foo<'a> = [> #Blue | #DeepBlue | #LightBlue ] as 'a
+type foo<'a> = @decorator [> #Blue | #DeepBlue | #LightBlue ] as 'a
 type t<'w> = [M.t<'w>]
 
 ---
@@ -250,6 +250,7 @@ type t<'w> = [M.t<'w>]
     (type_identifier)
     (type_parameters (type_identifier))
     (polyvar_type
+      (decorator (decorator_identifier))
       (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration (polyvar_identifier))
       (polyvar_declaration (polyvar_identifier))


### PR DESCRIPTION
### Bug Fix

1. Decorator before `polyvar_type`:

```res
type barStyle = @string [
  | #default
  | @as("light-content") #lightContent
  | @as("dark-content") #darkContent
]
```

```
yarn run v1.22.19
$ /home/pedro/Desktop/projects/tree-sitter-rescript/node_modules/.bin/tree-sitter parse ../../test-filetypes/rescript_print.res
(source_file [0, 0] - [5, 0]
  (type_declaration [0, 0] - [4, 1]
    (type_identifier [0, 5] - [0, 13])
    (ERROR [0, 16] - [0, 23]
      (decorator [0, 16] - [0, 23]
        (decorator_identifier [0, 17] - [0, 23])))
    (polyvar_type [0, 24] - [4, 1]
      (polyvar_declaration [1, 4] - [1, 12]
        (polyvar_identifier [1, 4] - [1, 12]))
      (polyvar_declaration [2, 4] - [2, 38]
        (decorator [2, 4] - [2, 24]
          (decorator_identifier [2, 5] - [2, 7])
          (decorator_arguments [2, 7] - [2, 24]
            (string [2, 8] - [2, 23]
              (string_fragment [2, 9] - [2, 22]))))
        (polyvar_identifier [2, 25] - [2, 38]))
      (polyvar_declaration [3, 4] - [3, 36]
        (decorator [3, 4] - [3, 23]
          (decorator_identifier [3, 5] - [3, 7])
          (decorator_arguments [3, 7] - [3, 23]
            (string [3, 8] - [3, 22]
              (string_fragment [3, 9] - [3, 21]))))
        (polyvar_identifier [3, 24] - [3, 36])))))
../../test-filetypes/rescript_print.res	0 ms	(ERROR [0, 16] - [0, 23])
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

2. Decorator after `labeled_argument`

```res
call(~a=@this (a, b) => a + b)
```

```
yarn run v1.22.19
$ /home/pedro/Desktop/projects/tree-sitter-rescript/node_modules/.bin/tree-sitter parse ../../test-filetypes/rescript_print.res
(source_file [0, 0] - [1, 0]
  (expression_statement [0, 0] - [0, 30]
    (call_expression [0, 0] - [0, 30]
      function: (value_identifier [0, 0] - [0, 4])
      arguments: (arguments [0, 4] - [0, 30]
        (labeled_argument [0, 5] - [0, 29]
          label: (value_identifier [0, 6] - [0, 7])
          (ERROR [0, 8] - [0, 13]
            (ERROR [0, 9] - [0, 13]))
          value: (function [0, 14] - [0, 29]
            parameters: (formal_parameters [0, 14] - [0, 20]
              (parameter [0, 15] - [0, 16]
                (value_identifier [0, 15] - [0, 16]))
              (parameter [0, 18] - [0, 19]
                (value_identifier [0, 18] - [0, 19])))
            body: (binary_expression [0, 24] - [0, 29]
              left: (value_identifier [0, 24] - [0, 25])
              right: (value_identifier [0, 28] - [0, 29]))))))))
../../test-filetypes/rescript_print.res	0 ms	(ERROR [0, 8] - [0, 13])
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

### Add more support for:

- Array/Array pattern `[@decorator 1, @decorator 2]`
- List/List pattern `list{@decorator hd, @decorator tail}`
- Tuple/Tuple pattern (See [rescript-tea](https://github.com/darklang/rescript-tea/blob/7f9edefda90db35593e0ecf986ae316d2f19abee/src/tea_task.res#L142)) `(@decorator 1, @decorator 2)`

### Test

- Add [rescript-nodejs](https://github.com/TheSpyder/rescript-nodejs) to test-wild