### PR TITLE
fix: relax template string prefix

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1457,11 +1457,13 @@ module.exports = grammar({
 
     template_string: $ => seq(
       token(seq(
-        optional(choice(
-          'j',
-          'js',
-          'json',
-        )),
+        optional(
+          choice(
+            /[a-z_][a-zA-Z0-9_']*/,
+            // escape_sequence
+            seq('\\"', /[^"]+/ , '"'),
+          )
+        ),
         '`',
       )),
       $.template_string_content,

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -130,6 +130,8 @@ The caller should either handle this error, or expect that exit code.`
 
 `\\`
 
+anything`Hello`
+
 ----
 
 (source_file
@@ -156,7 +158,8 @@ The caller should either handle this error, or expect that exit code.`
       (escape_sequence)
       (template_substitution (value_identifier)))))
   (expression_statement (template_string (template_string_content)))
-  (expression_statement (template_string (template_string_content (escape_sequence)))))
+  (expression_statement (template_string (template_string_content (escape_sequence))))
+  (expression_statement (template_string (template_string_content))))
 
 ============================================
 Tricky template strings


### PR DESCRIPTION
Any prefix is valid by syntax, but is removed on compilation.

See [playground](https://rescript-lang.org/try?code=DYUwLgBAhhC8ECsDOB7AdgAwN4DMUCcBbKMALgCIBXMHADnIBoIBLNAY2EoBMQBlMSjhykIOKMCQgAvhgBQoSACM40NAE8wAC1YYAEiGDAUchRDYqAOuS3Mk5PQaMYgA)