### PR TITLE
allow `unpack` as a valid identifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -66,6 +66,7 @@ module.exports = grammar({
     ],
     [$._jsx_attribute_value, $.pipe_expression],
     [$.function_type_parameters, $.function_type],
+    [$._reserved_identifier, $.module_unpack]
   ],
 
   conflicts: $ => [
@@ -1495,7 +1496,8 @@ module.exports = grammar({
     uncurry: $ => '.',
 
     _reserved_identifier: $ => choice(
-      'async'
+      'async',
+      'unpack'
     )
   },
 });

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -114,12 +114,13 @@
   "assert"
   "await"
   "with"
-  "unpack"
   "lazy"
   "constraint"
 ] @keyword
 
 ((function "async" @keyword))
+
+(module_unpack "unpack" @keyword)
 
 [
   "if"

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -8,6 +8,7 @@ let c = #foo
 let list = 1
 let a = list
 let async = 1
+let unpack = 2
 export d = 5
 
 ---
@@ -23,6 +24,8 @@ export d = 5
     (let_binding (value_identifier) (number)))
   (let_declaration
     (let_binding (value_identifier) (value_identifier)))
+  (let_declaration
+    (let_binding (value_identifier) (number)))
   (let_declaration
     (let_binding (value_identifier) (number)))
   (let_declaration


### PR DESCRIPTION
`unpack` can be an identifier.

[Playground example](https://rescript-lang.org/try?version=v10.1.2&code=DYUwLgBArgdgDgQwMYGsIF4IEYBQOC2A9gCZSgRgCecIEAGhhAN44QXW1h5uiQLHEAXBAAUASxhgANBAlgAlBgB8syTgC+eKjQgAzRkVKgRdeXl4QEBkmRAjWzB222cnEC-2KMRCGQCNFdBUrAGoIPwd1YTocMwIbcgAhRlhEVB8zIA)