### PR TITLE
try_expression: allow `expression`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -718,10 +718,7 @@ module.exports = grammar({
 
     try_expression: $ => seq(
       'try',
-      choice(
-        $.block,
-        $.primary_expression,
-      ),
+      $.expression,
       'catch',
       '{',
       repeat($.switch_match),

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1273,7 +1273,7 @@ try switch foo() {
 | Js.Exn.Error(obj) => "error"
 }
 
-try if true {
+try for i in 0 to 10 {
   call()
 } catch {
 | Not_found => false
@@ -1330,7 +1330,7 @@ try if true {
 
   (expression_statement
     (try_expression
-      (if_expression (true)
+      (for_expression (value_identifier) (number) (number)
         (block
           (expression_statement
             (call_expression (value_identifier) (arguments)))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1273,6 +1273,12 @@ try switch foo() {
 | Js.Exn.Error(obj) => "error"
 }
 
+try if true {
+  call()
+} catch {
+| Not_found => false
+} 
+
 ---
 
 (source_file
@@ -1320,7 +1326,17 @@ try switch foo() {
               (module_identifier))
             (variant_identifier))
           (formal_parameters (value_identifier)))
-        (sequence_expression (expression_statement (string (string_fragment))))))))
+        (sequence_expression (expression_statement (string (string_fragment)))))))
+
+  (expression_statement
+    (try_expression
+      (if_expression (true)
+        (block
+          (expression_statement
+            (call_expression (value_identifier) (arguments)))))
+      (switch_match
+        (variant_pattern (variant_identifier))
+        (sequence_expression (expression_statement (false)))))))
 
 ===========================================
 Mutation expressions


### PR DESCRIPTION
```rescript
try for i in 0 to 200 {
  Js.log(i)
} catch {
| Not_found => ()
}
```

[Playground](https://rescript-lang.org/try?version=v10.1.2&code=C4JwngBAZg9iEEtEDsIAYLBhATGjA3gFAQQBSAzgHQA2MA5gBQICURAvhAMYCGwXACwjEAPhAByMYAH1YAV2QATCAF4AfBEZt2RIA)

```
(source_file [0, 0] - [5, 0]
  (expression_statement [0, 0] - [4, 1]
    (try_expression [0, 0] - [4, 1]
      (ERROR [0, 4] - [0, 21]
        (value_identifier [0, 4] - [0, 7])
        (ERROR [0, 8] - [0, 9])
        (number [0, 13] - [0, 14])
        (number [0, 18] - [0, 21]))
      (block [0, 22] - [2, 1]
        (expression_statement [1, 2] - [1, 11]
          (call_expression [1, 2] - [1, 11]
            function: (value_identifier_path [1, 2] - [1, 8]
              (module_identifier [1, 2] - [1, 4])
              (value_identifier [1, 5] - [1, 8]))
            arguments: (arguments [1, 8] - [1, 11]
              (value_identifier [1, 9] - [1, 10])))))
      (switch_match [3, 0] - [3, 17]
        pattern: (variant_pattern [3, 2] - [3, 11]
          (variant_identifier [3, 2] - [3, 11]))
        body: (sequence_expression [3, 15] - [3, 17]
          (expression_statement [3, 15] - [3, 17]
            (unit [3, 15] - [3, 17])))))))

``` 