### PR TITLE
Fix include_statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -113,7 +113,8 @@ module.exports = grammar({
     [$.polyvar_type],
     [$.let_binding, $.or_pattern],
     [$.exception_pattern, $.or_pattern],
-    [$.type_binding, $._inline_type]
+    [$.type_binding, $._inline_type],
+    [$._module_structure, $.parenthesized_module_expression]
   ],
 
   rules: {
@@ -176,7 +177,10 @@ module.exports = grammar({
 
     include_statement: $ => seq(
       'include',
-      $.module_expression,
+      choice(
+        $._module_definition,
+        parenthesize($._module_structure)
+      )
     ),
 
     declaration: $ => choice(
@@ -204,6 +208,11 @@ module.exports = grammar({
       optional('rec'),
       optional('type'),
       sep1('and', $.module_binding)
+    ),
+
+    _module_structure: $ => seq(
+      $._module_definition,
+      optional($.module_type_annotation),
     ),
 
     _module_definition: $ => choice(
@@ -757,13 +766,7 @@ module.exports = grammar({
 
     module_pack: $ => seq(
       'module',
-      '(',
-      choice(
-        $.type_identifier_path,
-        $._module_definition,
-      ),
-      optional($.module_type_annotation),
-      ')'
+      parenthesize(choice($._module_structure, $.type_identifier_path))
     ),
 
     call_arguments: $ => seq(
@@ -1536,4 +1539,8 @@ function sep1(delimiter, rule) {
 
 function path(prefix, final) {
   return choice(final, seq(prefix, '.', final))
+}
+
+function parenthesize(rule) {
+  return seq('(', rule, ')')
 }

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -32,6 +32,11 @@ include (Belt: module type of Belt with module Map.Inner := Belt.Map and module 
 include module type of {
   include T
 }
+include (
+  {
+    let a = Js.log("Hello")
+  }
+)
 
 ---
 
@@ -78,7 +83,15 @@ include module type of {
 
   (include_statement
     (module_type_of
-      (block (include_statement (module_identifier))))))
+      (block (include_statement (module_identifier)))))
+
+  (include_statement
+    (block
+      (let_declaration
+        (let_binding (value_identifier)
+        (call_expression
+          (value_identifier_path (module_identifier) (value_identifier))
+          (arguments (string (string_fragment)))))))))
 
 ===========================================
 Simple definition


### PR DESCRIPTION
```rescript
include (
  {
    let a = Js.log("Hello")
  }: {
    let a: unit
  }
)
``` 

```
(source_file [0, 0] - [7, 0]
  (ERROR [0, 0] - [0, 9])
  (ERROR [1, 2] - [3, 4]
    (block [1, 2] - [3, 3]
      (let_declaration [2, 4] - [2, 27]
        (let_binding [2, 8] - [2, 27]
          pattern: (value_identifier [2, 8] - [2, 9])
          body: (call_expression [2, 12] - [2, 27]
            function: (value_identifier_path [2, 12] - [2, 18]
              (module_identifier [2, 12] - [2, 14])
              (value_identifier [2, 15] - [2, 18]))
            arguments: (arguments [2, 18] - [2, 27]
              (string [2, 19] - [2, 26]
                (string_fragment [2, 20] - [2, 25]))))))))
  (expression_statement [3, 5] - [5, 3]
    (block [3, 5] - [5, 3]
      (let_declaration [4, 4] - [4, 15]
        (let_binding [4, 8] - [4, 15]
          pattern: (value_identifier [4, 8] - [4, 9])
          (type_annotation [4, 9] - [4, 15]
            (unit_type [4, 11] - [4, 15]))))))
  (ERROR [6, 0] - [6, 1]))
``` 

[Playground](https://rescript-lang.org/try?version=v10.1.2&code=JYOwxgNgrgJgpgAgBQCgEIN5vQicAuCAhggLwIBSAzgHQQD2A5kgEQAScEDLAlNgL4AuTNnR5CRYVBDB8AlHxShIsRFnT4AngAdEc9MujxkokThziEAMzIIAHmQB8900LPncBa8MKln+nH5sPiCgA)