### PR TITLE
Move inline decorator to scanner

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -10,11 +10,14 @@ module.exports = grammar({
     $._template_chars,
     $._lparen,
     $._rparen,
-    $._list_constructor
+    $._list_constructor,
+    $._decorator,
+    $._decorator_inline,
   ],
 
   extras: $ => [
     $.comment,
+    $.decorator,
     /[\s\uFEFF\u2060\u200B\u00A0]/
   ],
 
@@ -77,41 +80,28 @@ module.exports = grammar({
     [$.primary_expression, $._literal_pattern],
     [$.primary_expression, $.lazy_pattern],
     [$.primary_expression, $._jsx_child],
-    [$.tuple_pattern, $.parameter],
-    [$.primary_expression, $.parameter],
-    [$.primary_expression, $.record_field],
     [$.tuple_type, $.function_type_parameter],
     [$.list, $.list_pattern],
     [$.array, $.array_pattern],
-    [$.record_field, $.record_pattern],
-    [$.expression_statement, $.ternary_expression],
     [$.type_declaration],
-    [$.type_binding],
     [$.let_declaration],
-    [$.let_declaration, $.ternary_expression],
     [$.variant_identifier, $.module_identifier],
     [$.variant, $.variant_pattern],
-    [$.variant_declaration, $.function_type_parameter],
     [$.variant_arguments, $._variant_pattern_parameters],
     [$.polyvar, $.polyvar_pattern],
     [$._pattern],
-    [$._record_element, $.jsx_expression],
     [$._record_element, $._record_single_field],
     [$._record_pun_field, $._record_single_pun_field],
     [$._record_field_name, $.record_pattern],
-    [$.decorator],
     [$._statement, $._one_or_more_statements],
     [$._inline_type, $.function_type_parameters],
     [$.primary_expression, $.parameter, $._pattern],
     [$.parameter, $._pattern],
     [$.parameter, $.parenthesized_pattern],
     [$.parameter, $.tuple_item_pattern],
-    [$.variant_declaration],
     [$.unit, $._function_type_parameter_list],
     [$.functor_parameter, $.module_primary_expression, $.module_identifier_path],
     [$._reserved_identifier, $.function],
-    [$.polyvar_type],
-    [$.let_binding, $.or_pattern],
     [$.exception_pattern, $.or_pattern],
     [$.type_binding, $._inline_type],
     [$._module_structure, $.parenthesized_module_expression]
@@ -141,26 +131,10 @@ module.exports = grammar({
     ),
 
     statement: $ => choice(
-      alias($._decorated_statement, $.decorated),
-      $.decorator_statement,
       $.expression_statement,
       $.declaration,
       $.open_statement,
       $.include_statement,
-    ),
-
-    _decorated_statement: $ => seq(
-      repeat1($.decorator),
-      choice(
-        $.declaration,
-        $.expression_statement
-      )
-    ),
-
-    decorator_statement: $ => seq(
-      '@@',
-      $.decorator_identifier,
-      optional($.decorator_arguments)
     ),
 
     block: $ => prec.right(seq(
@@ -282,7 +256,7 @@ module.exports = grammar({
       'type',
       optional('rec'),
       sep1(
-        seq(repeat($._newline), repeat($.decorator), 'and'),
+        seq(repeat($._newline), 'and'),
         $.type_binding
       )
     ),
@@ -314,7 +288,6 @@ module.exports = grammar({
 
     type_annotation: $ => seq(
       ':',
-      repeat($.decorator),
       $._inline_type,
     ),
 
@@ -367,7 +340,6 @@ module.exports = grammar({
     )),
 
     variant_declaration: $ => prec.right(seq(
-      repeat($.decorator),
       $.variant_identifier,
       optional($.variant_parameters),
       optional($.type_annotation),
@@ -380,7 +352,6 @@ module.exports = grammar({
     ),
 
     polyvar_type: $ => prec.left(seq(
-      repeat($.decorator),
       choice('[', '[>', '[<',),
       optional('|'),
       barSep1($.polyvar_declaration),
@@ -390,7 +361,6 @@ module.exports = grammar({
     polyvar_declaration: $ => prec.right(
       choice(
         seq(
-          repeat($.decorator),
           $.polyvar_identifier,
           optional($.polyvar_parameters),
         ),
@@ -411,7 +381,6 @@ module.exports = grammar({
     ),
 
     record_type_field: $ => seq(
-      repeat($.decorator),
       optional('mutable'),
       alias($.value_identifier, $.property_identifier),
       optional('?'),
@@ -433,7 +402,6 @@ module.exports = grammar({
     object_type_field: $ => choice(
       seq('...', choice($.type_identifier, $.type_identifier_path)),
       seq(
-        repeat($.decorator),
         alias($.string, $.property_identifier),
         ':',
         $._type,
@@ -471,7 +439,6 @@ module.exports = grammar({
 
     function_type_parameter: $ => seq(
       optional($.uncurry),
-      repeat($.decorator),
       choice(
         $._type,
         seq($.uncurry, $._type),
@@ -483,7 +450,7 @@ module.exports = grammar({
       choice('export', 'let'),
       optional('rec'),
       sep1(
-        seq(repeat($._newline), repeat($.decorator), 'and'),
+        seq(repeat($._newline), 'and'),
         $.let_binding
       )
     ),
@@ -495,14 +462,12 @@ module.exports = grammar({
           $.type_annotation,
           optional(
             seq('=',
-              repeat($.decorator),
               field('body', $.expression)
             )
           )
         ),
         seq(
           '=',
-          repeat($.decorator),
           field('body', $.expression),
         )
       )
@@ -559,7 +524,6 @@ module.exports = grammar({
 
     parenthesized_expression: $ => seq(
       '(',
-      repeat($.decorator),
       $.expression,
       optional($.type_annotation),
       ')'
@@ -578,7 +542,6 @@ module.exports = grammar({
         $._definition_signature
       ),
       '=>',
-      repeat($.decorator),
       field('body', $.expression),
     )),
 
@@ -647,27 +610,21 @@ module.exports = grammar({
     tuple: $ => seq(
       '(',
       commaSep2t(
-        seq(repeat($.decorator), $.expression)
+        $.expression
       ),
       ')',
     ),
 
     array: $ => seq(
       '[',
-      commaSept(
-        seq(repeat($.decorator), $.expression)
-      ),
+      commaSept($.expression),
       ']'
     ),
 
     list: $ => seq(
       $._list_constructor,
       '{',
-      optional(
-        commaSep1t(
-          seq(repeat($.decorator), $._list_element)
-        )
-      ),
+      optional(commaSep1t($._list_element)),
       '}'
     ),
 
@@ -773,7 +730,6 @@ module.exports = grammar({
 
     _call_argument: $ => choice(
       seq(
-        repeat($.decorator),
         $.expression,
         optional($.type_annotation),
       ),
@@ -788,7 +744,6 @@ module.exports = grammar({
         seq(
           '=',
           optional('?'),
-          repeat($.decorator),
           field('value', $.expression),
           optional(field('type', $.type_annotation)),
         ),
@@ -933,7 +888,6 @@ module.exports = grammar({
     ),
 
     tuple_item_pattern: $ => seq(
-      repeat($.decorator),
       $._pattern,
       optional($.type_annotation),
     ),
@@ -947,7 +901,7 @@ module.exports = grammar({
     array_pattern: $ => seq(
       '[',
       optional(commaSep1t(
-        seq(repeat($.decorator), $._collection_element_pattern)
+        $._collection_element_pattern
       )),
       ']',
     ),
@@ -955,9 +909,7 @@ module.exports = grammar({
     list_pattern: $ => seq(
       $._list_constructor,
       '{',
-      optional(commaSep1t(
-        seq(repeat($.decorator), $._collection_element_pattern)
-      )),
+      optional(commaSep1t($._collection_element_pattern)),
       '}',
     ),
 
@@ -1089,10 +1041,9 @@ module.exports = grammar({
       $.expression,
     ),
 
-    decorator: $ => seq(
-      '@',
-      $.decorator_identifier,
-      optional($.decorator_arguments)
+    decorator: $ => choice(
+      alias($._decorator_inline, $.decorator_identifier),
+      seq(alias($._decorator, $.decorator_identifier), $.decorator_arguments)
     ),
 
     decorator_arguments: $ => seq(
@@ -1364,8 +1315,6 @@ module.exports = grammar({
     _escape_identifier: $ => token(seq('\\"', /[^"]+/, '"')),
 
     module_identifier: $ => /[A-Z][a-zA-Z0-9_']*/,
-
-    decorator_identifier: $ => /[a-zA-Z0-9_\.]+/,
 
     extension_identifier: $ => /[a-zA-Z0-9_\.]+/,
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -80,11 +80,7 @@
 ; Meta
 ;-----
 
-[
- "@"
- "@@"
- (decorator_identifier)
-] @annotation
+(decorator_identifier) @annotation
 
 (extension_identifier) @keyword
 ("%") @keyword

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -1,149 +1,61 @@
 ============================================
-This decorator
+Decorator inline
 ============================================
 
-foo(bar, @this (me, amount) => set(me, amount))
+@@deprecated
+@@Uppercase
+@@Upper._2323
+@@_.decorator
+@@_.1decorator
+@@_123
+@@\"escape"
+@@\"de.2precated"
 
 ---
 
 (source_file
-  (expression_statement
-    (call_expression
-      (value_identifier)
-      (arguments
-        (value_identifier)
-        (decorator (decorator_identifier))
-        (function
-          (formal_parameters
-            (parameter (value_identifier))
-            (parameter (value_identifier)))
-          (call_expression
-            (value_identifier)
-            (arguments
-              (value_identifier)
-              (value_identifier))))))))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier))
+  (decorator (decorator_identifier)))
+
 
 ============================================
-Reanalyze Decorator
+Decorator with arguments
 ============================================
 
-let foo = (@doesNotRaise String.make)(12, ' ')
-
-let foo = @doesNotRaise String.make(12, ' ')
-
-let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
-
-@local
-call()
+@@deprecated()
+@@Uppercase()
+@@Upper._2323()
+@@_.decorator()
+@@_.1decorator()
+@@_123()
+@@\"escape"()
+@@\"de.2precated"()
 
 ---
 
 (source_file
-  (let_declaration
-    (let_binding
-      (value_identifier)
-      (call_expression
-        (parenthesized_expression
-          (decorator (decorator_identifier))
-          (value_identifier_path
-            (module_identifier)
-            (value_identifier)))
-        (arguments
-          (number)
-          (character)))))
-
-  (let_declaration
-    (let_binding
-      (value_identifier)
-      (decorator (decorator_identifier))
-      (call_expression
-        (value_identifier_path
-          (module_identifier)
-          (value_identifier))
-        (arguments
-          (number)
-          (character)))))
-
-  (let_declaration
-    (let_binding
-      (value_identifier)
-      (function
-        (formal_parameters)
-        (decorator (decorator_identifier))
-        (call_expression
-          (value_identifier_path
-            (module_identifier_path
-              (module_identifier)
-              (module_identifier))
-            (value_identifier))
-          (arguments
-            (array)
-            (number))))))
-
-  (decorated
-    (decorator (decorator_identifier))
-    (expression_statement
-      (call_expression
-        (value_identifier) (arguments)))))
-
-============================================
-Decorator before type `and`
-============================================
-
-@deriving
-type foo = {
-  foo: string
-}
-@deriving
-and bar = {bar: int}
-
-
-@deriving @hello and baz = {baz: float}
-
----
-
-(source_file
-  (decorated
-    (decorator (decorator_identifier))
-    (type_declaration
-      (type_binding
-        (type_identifier)
-        (record_type (record_type_field (property_identifier) (type_annotation (type_identifier)))))
-      (decorator (decorator_identifier))
-      (type_binding
-        (type_identifier)
-        (record_type (record_type_field (property_identifier) (type_annotation (type_identifier)))))
-        (decorator (decorator_identifier))
-        (decorator (decorator_identifier))
-        (type_binding
-          (type_identifier)
-          (record_type (record_type_field (property_identifier) (type_annotation (type_identifier))))))))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments))
+  (decorator (decorator_identifier) (decorator_arguments)))
 
 ============================================
 Decorator with type
 ============================================
 
 @react.component(:sharedProps)
-let make = (~x, ~y) => React.string(x ++ y)
 
 ---
 
 (source_file
-  (decorated
-    (decorator
-      (decorator_identifier)
-      (decorator_arguments
-        (type_annotation (type_identifier))))
-    (let_declaration
-      (let_binding
-        (value_identifier)
-        (function
-          (formal_parameters
-            (parameter (labeled_parameter (value_identifier)))
-            (parameter (labeled_parameter (value_identifier))))
-          (call_expression
-            (value_identifier_path
-              (module_identifier) (value_identifier))
-            (arguments
-              (binary_expression
-                (value_identifier) (value_identifier)))))))))
+  (decorator (decorator_identifier) (decorator_arguments (type_annotation (type_identifier)))))

--- a/test/corpus/let_bindings.txt
+++ b/test/corpus/let_bindings.txt
@@ -295,21 +295,20 @@ and b = c
 ---
 
 (source_file
-  (decorated
+  (decorator (decorator_identifier))
+  (let_declaration
+    (let_binding
+      (value_identifier)
+      (value_identifier))
     (decorator (decorator_identifier))
-    (let_declaration
-      (let_binding
-        (value_identifier)
-        (value_identifier))
-      (decorator (decorator_identifier))
-        (decorator (decorator_identifier))
-      (let_binding
-        (value_identifier)
-        (value_identifier))
-      (decorator (decorator_identifier))
-      (let_binding
-        (value_identifier)
-        (number)))))
+    (decorator (decorator_identifier))
+    (let_binding
+      (value_identifier)
+      (value_identifier))
+    (decorator (decorator_identifier))
+    (let_binding
+      (value_identifier)
+      (number))))
 
 ===========================================
 Labled function with uncurried

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -234,6 +234,7 @@ Characters
 '\o021'
 '\179'
 '\u{1F600}'
+'@'
 
 ---
 
@@ -245,7 +246,8 @@ Characters
   (expression_statement (character))
   (expression_statement (character (escape_sequence)))
   (expression_statement (character (escape_sequence)))
-  (expression_statement (character (escape_sequence))))
+  (expression_statement (character (escape_sequence)))
+  (expression_statement (character)))
 
 ============================================
 Polyvars

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -461,27 +461,26 @@ external add: (
         (function_type_parameters (type_identifier))
         (type_identifier)))
     (string (string_fragment)))
-  (decorated
-    (decorator (decorator_identifier))
-    (external_declaration
-      (value_identifier)
-      (type_annotation (type_identifier))
-      (string (string_fragment))))
-  (decorated
-    (decorator (decorator_identifier))
-    (external_declaration
-      (value_identifier)
-      (type_annotation (type_identifier))
-      (string (string_fragment))))
-  (decorated
-    (decorator
-      (decorator_identifier)
-      (decorator_arguments (string (string_fragment))))
-    (decorator (decorator_identifier))
-    (external_declaration
-      (value_identifier)
-      (type_annotation (type_identifier))
-      (string (string_fragment))))
+
+  (decorator (decorator_identifier))
+  (external_declaration
+    (value_identifier)
+    (type_annotation (type_identifier))
+    (string (string_fragment)))
+
+  (decorator (decorator_identifier))
+  (external_declaration
+    (value_identifier)
+    (type_annotation (type_identifier))
+    (string (string_fragment)))
+
+  (decorator (decorator_identifier) (decorator_arguments (string (string_fragment))))
+  (decorator (decorator_identifier))
+  (external_declaration
+    (value_identifier)
+    (type_annotation (type_identifier))
+    (string (string_fragment)))
+
   (external_declaration
     (value_identifier)
     (type_annotation
@@ -491,63 +490,51 @@ external add: (
           (parameter (uncurry) (unit_type)))
         (object_type)))
     (string (string_fragment)))
-  (decorated
-    (decorator (decorator_identifier))
-    (external_declaration
-      (value_identifier)
-      (type_annotation
-        (function_type
-          (function_type_parameters
-            (parameter
-              (type_identifier_path (module_identifier) (type_identifier)))
-            (parameter
-              (decorator (decorator_identifier) (decorator_arguments (template_string (template_string_content))))
-              (type_identifier))
-            (parameter
-              (decorator (decorator_identifier) (decorator_arguments (string)))
-              (type_identifier))
-            (parameter
-              (labeled_parameter
-                (value_identifier) (type_annotation (type_identifier)))))
-          (unit_type)))
-        (string (string_fragment))))
-  (decorated
-    (decorator (decorator_identifier))
-    (external_declaration
-      (value_identifier)
-      (type_annotation
-        (function_type
-          (function_type_parameters
-            (parameter (type_identifier))
-            (parameter
-              (labeled_parameter
-                (value_identifier)
-                (type_annotation
-                  (decorator (decorator_identifier))
-                  (polyvar_type
-                    (polyvar_declaration
-                      (polyvar_identifier)
-                      (polyvar_parameters
-                        (type_identifier_path (module_identifier) (type_identifier))))
-                    (polyvar_declaration
-                      (polyvar_identifier)
-                      (polyvar_parameters
-                        (type_identifier_path (module_identifier) (type_identifier)))))))))
-          (unit_type)))
-        (string (string_fragment)))))
 
-===========================================
-Decorators
-===========================================
 
-@@warning("-27")
+  (decorator (decorator_identifier))
+  (external_declaration
+    (value_identifier)
+    (type_annotation
+      (function_type
+        (function_type_parameters
+          (parameter
+            (type_identifier_path (module_identifier) (type_identifier)))
+          (decorator (decorator_identifier) (decorator_arguments (template_string (template_string_content))))
+          (parameter
+            (type_identifier))
+          (decorator (decorator_identifier) (decorator_arguments (string)))
+          (parameter
+            (type_identifier))
+          (parameter
+            (labeled_parameter
+              (value_identifier) (type_annotation (type_identifier)))))
+        (unit_type)))
+      (string (string_fragment)))
 
----
-
-(source_file
-  (decorator_statement
-    (decorator_identifier)
-    (decorator_arguments (string (string_fragment)))))
+  (decorator (decorator_identifier))
+  (external_declaration
+    (value_identifier)
+    (type_annotation
+      (function_type
+        (function_type_parameters
+          (parameter (type_identifier))
+          (parameter
+            (labeled_parameter
+              (value_identifier)
+              (type_annotation
+                (decorator (decorator_identifier))
+                (polyvar_type
+                  (polyvar_declaration
+                    (polyvar_identifier)
+                    (polyvar_parameters
+                      (type_identifier_path (module_identifier) (type_identifier))))
+                  (polyvar_declaration
+                    (polyvar_identifier)
+                    (polyvar_parameters
+                      (type_identifier_path (module_identifier) (type_identifier)))))))))
+        (unit_type)))
+      (string (string_fragment))))
 
 ===========================================
 Exception declaration

--- a/test/corpus/type_declarations.txt
+++ b/test/corpus/type_declarations.txt
@@ -104,10 +104,10 @@ type t = {}
           (property_identifier) (type_annotation (type_identifier)))
         (record_type_field
           (property_identifier) (type_annotation (type_identifier)))
-        (record_type_field
-          (decorator
+        (decorator
             (decorator_identifier)
             (decorator_arguments (string (string_fragment))))
+        (record_type_field
           (property_identifier)
           (type_annotation (type_identifier)))
         (record_type_field
@@ -183,8 +183,8 @@ type t =
       (variant_type
         (variant_declaration (variant_identifier))
         (variant_declaration (variant_identifier))
+        (decorator (decorator_identifier) (decorator_arguments (string (string_fragment))))
         (variant_declaration
-          (decorator (decorator_identifier) (decorator_arguments (string (string_fragment))))
           (variant_identifier))
         (variant_declaration
           (variant_identifier) (variant_parameters (type_identifier)))
@@ -257,16 +257,17 @@ type t<'w> = [M.t<'w>]
         (polyvar_declaration (polyvar_identifier (polyvar_string (string_fragment))))
         (polyvar_declaration (polyvar_identifier (polyvar_string (string_fragment))))
         (polyvar_declaration (polyvar_identifier))
-        (polyvar_declaration (decorator (decorator_identifier) (decorator_arguments (string (string_fragment)))) (polyvar_identifier))
+        (decorator (decorator_identifier) (decorator_arguments (string (string_fragment))))
+        (polyvar_declaration (polyvar_identifier))
         (polyvar_declaration (type_identifier)))))
 
   (type_declaration
     (type_binding
       (type_identifier)
       (type_parameters (type_identifier))
+      (decorator (decorator_identifier))
       (as_aliasing_type
         (polyvar_type
-          (decorator (decorator_identifier))
           (polyvar_declaration (polyvar_identifier))
           (polyvar_declaration (polyvar_identifier))
           (polyvar_declaration (polyvar_identifier)))
@@ -436,22 +437,21 @@ type person = {@meth "say": (string, string) => unit}
 ---
 
 (source_file
-  (decorated
-    (decorator (decorator_identifier) (decorator_arguments (value_identifier)))
-    (type_declaration
-      (type_binding
-        (type_identifier)
-        (record_type
-          (record_type_field
-            (property_identifier)
-            (type_annotation (type_identifier)))))))
+  (decorator (decorator_identifier) (decorator_arguments (value_identifier)))
+  (type_declaration
+    (type_binding
+      (type_identifier)
+      (record_type
+        (record_type_field
+          (property_identifier)
+          (type_annotation (type_identifier))))))
 
   (type_declaration
     (type_binding
       (type_identifier)
       (object_type
+        (decorator (decorator_identifier))
         (field
-          (decorator (decorator_identifier))
           (property_identifier (string_fragment))
           (function_type
             (function_type_parameters

--- a/test/highlight/decorators.res
+++ b/test/highlight/decorators.res
@@ -1,0 +1,5 @@
+@name
+//<- annotation
+
+@@name
+//<- annotation


### PR DESCRIPTION
Move inline decorator to scanner.

Inline decorator is decorator without arguments.

```rescript
@@decorator
@decorator
``` 

Decorators with arguments can be specified in `grammar.js`. This was a limitation because TreeSitter could not determine the end of the rule. 

Decorators can now be treated as a comment, can appear anywhere.

This PR also removes some conflicts that were introduced due to decorators. We can also remove some tests with decorators.