### PR TITLE
Remove `decorator_identifier` node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1042,8 +1042,8 @@ module.exports = grammar({
     ),
 
     decorator: $ => choice(
-      alias($._decorator_inline, $.decorator_identifier),
-      seq(alias($._decorator, $.decorator_identifier), $.decorator_arguments)
+      $._decorator_inline,
+      seq($._decorator, $.decorator_arguments)
     ),
 
     decorator_arguments: $ => seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -80,7 +80,7 @@
 ; Meta
 ;-----
 
-(decorator_identifier) @annotation
+(decorator) @annotation
 
 (extension_identifier) @keyword
 ("%") @keyword

--- a/test/corpus/decorators.txt
+++ b/test/corpus/decorators.txt
@@ -14,22 +14,14 @@ Decorator inline
 --------------------------------------------------------------------------------
 
 (source_file
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier))
-  (decorator
-    (decorator_identifier)))
+  (decorator)
+  (decorator)
+  (decorator)
+  (decorator)
+  (decorator)
+  (decorator)
+  (decorator)
+  (decorator))
 
 ================================================================================
 Decorator with arguments
@@ -48,28 +40,20 @@ Decorator with arguments
 
 (source_file
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments))
   (decorator
-    (decorator_identifier)
     (decorator_arguments)))
 
 ================================================================================
@@ -82,7 +66,6 @@ Decorator with type
 
 (source_file
   (decorator
-    (decorator_identifier)
     (decorator_arguments
       (type_annotation
         (type_identifier)))))


### PR DESCRIPTION
Since #218, the `decorator` node is the same as `decorator_identifier`