### PR TITLE
Scanner: add type specifier missing

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -151,7 +151,7 @@ bool tree_sitter_rescript_external_scanner_scan(
     const bool* valid_symbols
     ) {
   ScannerState* state = (ScannerState*)payload;
-  bool const in_string = state->in_quotes || state->in_backticks;
+  bool in_string = state->in_quotes || state->in_backticks;
 
   while (is_inline_whitespace(lexer->lookahead) && !in_string) {
     skip(lexer);

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -151,7 +151,7 @@ bool tree_sitter_rescript_external_scanner_scan(
     const bool* valid_symbols
     ) {
   ScannerState* state = (ScannerState*)payload;
-  const in_string = state->in_quotes || state->in_backticks;
+  bool const in_string = state->in_quotes || state->in_backticks;
 
   while (is_inline_whitespace(lexer->lookahead) && !in_string) {
     skip(lexer);


### PR DESCRIPTION
I got the following error when compile to wasm on CI:

```
src/scanner.c:154:9: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  const in_string = state->in_quotes || state->in_backticks;
  ~~~~~ ^
  int
1 error generated.
emcc: error: '/emsdk/upstream/bin/clang -target wasm32-unknown-emscripten -fignore-exceptions -fPIC -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -DEMSCRIPTEN -Werror=implicit-function-declaration -I/emsdk/upstream/emscripten/cache/sysroot/include/SDL --sysroot=/emsdk/upstream/emscripten/cache/sysroot -Xclang -iwithsysroot/include/compat -Os -fno-exceptions -Isrc src/scanner.c -c -o /tmp/emscripten_temp_kz9rxsh8/scanner_0.o' failed (returned 1)
```

