### PR TITLE
Add regex support

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -464,6 +464,7 @@ module.exports = grammar({
         $.extension_expression,
         $.lazy_expression,
         $._jsx_element,
+        $.regex,
       ),
 
     parenthesized_expression: ($) =>
@@ -752,6 +753,7 @@ module.exports = grammar({
         $.number,
         $.true,
         $.false,
+        $.regex,
       ),
 
     variant_pattern: ($) =>
@@ -1184,6 +1186,30 @@ module.exports = grammar({
     module_identifier: ($) => /[A-Z][a-zA-Z0-9_']*/,
 
     extension_identifier: ($) => /[a-zA-Z0-9_\.]+/,
+
+    regex: ($) =>
+      seq(
+        "/",
+        field("pattern", $.regex_pattern),
+        token.immediate(prec(1, "/")),
+        optional(field("flags", $.regex_flags)),
+      ),
+
+    regex_pattern: (_) =>
+      token.immediate(
+        prec(
+          -1,
+          repeat1(
+            choice(
+              seq("[", repeat(choice(seq("\\", /./), /[^\]\n\\]/)), "]"),
+              seq("\\", /./),
+              /[^/\\\[\n]/,
+            ),
+          ),
+        ),
+      ),
+
+    regex_flags: (_) => token.immediate(/[a-z]+/),
 
     number: ($) => {
       // OCaml: https://github.com/tree-sitter/tree-sitter-ocaml/blob/f1106bf834703f1f2f795da1a3b5f8f40174ffcc/ocaml/grammar.js#L26

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -73,6 +73,8 @@
 ] @string
 
 
+(regex) @string.special
+
 (character) @character
 (escape_sequence) @string.escape
 

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,5 +1,9 @@
 ((comment) @injection.content (#set! injection.language "comment"))
 
+; regex literal
+(regex
+  (regex_pattern) @injection.content (#set! injection.language "regex"))
+
 ; %re
 (extension_expression
   (extension_identifier) @_name
@@ -26,4 +30,3 @@
   (#eq? @_name "relay")
   (expression_statement
     (_ (_) @injection.content (#set! injection.language "graphql") )))
-

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2428,6 +2428,10 @@
         {
           "type": "SYMBOL",
           "name": "_jsx_element"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "regex"
         }
       ]
     },
@@ -4339,6 +4343,10 @@
         {
           "type": "SYMBOL",
           "name": "false"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "regex"
         }
       ]
     },
@@ -7435,6 +7443,127 @@
     "extension_identifier": {
       "type": "PATTERN",
       "value": "[a-zA-Z0-9_\\.]+"
+    },
+    "regex": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "SYMBOL",
+            "name": "regex_pattern"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "STRING",
+              "value": "/"
+            }
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "flags",
+              "content": {
+                "type": "SYMBOL",
+                "name": "regex_flags"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "regex_pattern": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "["
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\\"
+                            },
+                            {
+                              "type": "PATTERN",
+                              "value": "."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "[^\\]\\n\\\\]"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "]"
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "\\"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "."
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^/\\\\\\[\\n]"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "regex_flags": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "[a-z]+"
+      }
     },
     "number": {
       "type": "TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -282,6 +282,10 @@
         "named": true
       },
       {
+        "type": "regex",
+        "named": true
+      },
+      {
         "type": "string",
         "named": true
       },
@@ -487,6 +491,10 @@
           "named": true
         },
         {
+          "type": "regex",
+          "named": true
+        },
+        {
           "type": "spread_pattern",
           "named": true
         },
@@ -591,6 +599,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -1080,6 +1092,10 @@
           "named": true
         },
         {
+          "type": "regex",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         },
@@ -1233,6 +1249,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -1443,6 +1463,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -2245,6 +2269,10 @@
           "named": true
         },
         {
+          "type": "regex",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         },
@@ -2355,6 +2383,10 @@
           },
           {
             "type": "record_pattern",
+            "named": true
+          },
+          {
+            "type": "regex",
             "named": true
           },
           {
@@ -2503,6 +2535,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -2993,6 +3029,10 @@
           "named": true
         },
         {
+          "type": "regex",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         },
@@ -3101,6 +3141,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -3246,6 +3290,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -3614,6 +3662,10 @@
           "named": true
         },
         {
+          "type": "regex",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         },
@@ -3743,6 +3795,10 @@
           "named": true
         },
         {
+          "type": "regex",
+          "named": true
+        },
+        {
           "type": "string",
           "named": true
         },
@@ -3813,6 +3869,32 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "regex",
+    "named": true,
+    "fields": {
+      "flags": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "regex_flags",
+            "named": true
+          }
+        ]
+      },
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "regex_pattern",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4036,6 +4118,10 @@
           },
           {
             "type": "record_pattern",
+            "named": true
+          },
+          {
+            "type": "regex",
             "named": true
           },
           {
@@ -4273,6 +4359,10 @@
         },
         {
           "type": "record_pattern",
+          "named": true
+        },
+        {
+          "type": "regex",
           "named": true
         },
         {
@@ -5109,6 +5199,14 @@
   {
     "type": "rec",
     "named": false
+  },
+  {
+    "type": "regex_flags",
+    "named": true
+  },
+  {
+    "type": "regex_pattern",
+    "named": true
   },
   {
     "type": "string_fragment",

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -392,3 +392,73 @@ Polyvars
   (expression_statement
     (polyvar
       (polyvar_identifier))))
+
+================================================================================
+Regex literal
+================================================================================
+
+/hello/
+/pattern/gi
+/\d+/
+/[a-z]/
+/foo\/bar/
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (regex
+      (regex_pattern)))
+  (expression_statement
+    (regex
+      (regex_pattern)
+      (regex_flags)))
+  (expression_statement
+    (regex
+      (regex_pattern)))
+  (expression_statement
+    (regex
+      (regex_pattern)))
+  (expression_statement
+    (regex
+      (regex_pattern))))
+
+================================================================================
+Regex literal in let binding
+================================================================================
+
+let r = /foo/g
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (let_declaration
+    (let_binding
+      (value_identifier)
+      (regex
+        (regex_pattern)
+        (regex_flags)))))
+
+================================================================================
+Regex literal as function argument
+================================================================================
+
+let code = String.replaceRegExp(signature, /\\n/g, "\n")
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (let_declaration
+    (let_binding
+      (value_identifier)
+      (call_expression
+        (value_identifier_path
+          (module_identifier)
+          (value_identifier))
+        (arguments
+          (value_identifier)
+          (regex
+            (regex_pattern)
+            (regex_flags))
+          (string
+            (escape_sequence)))))))


### PR DESCRIPTION
Fixes #255 

I took inspiration (copied) from https://github.com/tree-sitter/tree-sitter-javascript, it seems rescript has the same regex syntax as js, couldn't find something official to confirm it.


I tested it using the zed extension everything works fine. Testing on a random file with contents:

```
let r = /\\n/g
```

Tree before:
```
(source_file [0, 0] - [1, 0]
  (ERROR [0, 0] - [0, 14]
    (value_identifier [0, 4] - [0, 5])
    (ERROR [0, 11] - [0, 12])
    (ERROR [0, 13] - [0, 14])))
```
Tree after:
```
(source_file [0, 0] - [1, 0]
  (let_declaration [0, 0] - [0, 14]
    (let_binding [0, 4] - [0, 14]
      pattern: (value_identifier [0, 4] - [0, 5])
      body: (regex [0, 8] - [0, 14]
        pattern: (regex_pattern [0, 9] - [0, 12])
        flags: (regex_flags [0, 13] - [0, 14])))))
```