### PR TITLE
Fix block comment not recognized inside switch expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -100,6 +100,7 @@ module.exports = grammar({
     [$._record_pun_field, $._record_single_pun_field],
     [$._record_field_name, $.record_pattern],
     [$._statement, $._one_or_more_statements],
+    [$._statement, $._switch_body],
     [$._inline_type, $.function_type_parameters],
     [$.primary_expression, $.parameter, $._pattern],
     [$.parameter, $._pattern],
@@ -133,6 +134,13 @@ module.exports = grammar({
 
     _one_or_more_statements: ($) =>
       seq(repeat($._statement), $.statement, optional($._statement_delimeter)),
+
+    // Like _one_or_more_statements but without a trailing delimiter.
+    // Used as switch_match / try-catch bodies so that trailing NEWLINEs
+    // (including those emitted between consecutive block comments) are
+    // absorbed by the enclosing switch/try rule instead of being orphaned.
+    _switch_body: ($) =>
+      seq(repeat($._statement), $.statement),
 
     statement: ($) =>
       choice(
@@ -589,7 +597,13 @@ module.exports = grammar({
     else_clause: ($) => seq("else", $.block),
 
     switch_expression: ($) =>
-      seq("switch", $.expression, "{", repeat($.switch_match), "}"),
+      seq(
+        "switch",
+        $.expression,
+        "{",
+        repeat(seq($.switch_match, repeat($._statement_delimeter))),
+        "}",
+      ),
 
     switch_match: ($) =>
       prec.dynamic(
@@ -601,7 +615,7 @@ module.exports = grammar({
           "=>",
           field(
             "body",
-            alias($._one_or_more_statements, $.sequence_expression),
+            alias($._switch_body, $.sequence_expression),
           ),
         ),
       ),
@@ -616,7 +630,14 @@ module.exports = grammar({
       seq($.variant_type_pattern, optional($.as_aliasing)),
 
     try_expression: ($) =>
-      seq("try", $.expression, "catch", "{", repeat($.switch_match), "}"),
+      seq(
+        "try",
+        $.expression,
+        "catch",
+        "{",
+        repeat(seq($.switch_match, repeat($._statement_delimeter))),
+        "}",
+      ),
 
     as_aliasing: ($) =>
       prec.left(seq("as", $._pattern, optional($.type_annotation))),

--- a/grammar.js
+++ b/grammar.js
@@ -253,7 +253,7 @@ module.exports = grammar({
         optional("export"),
         "type",
         optional("rec"),
-        sep1(seq(repeat($._newline), "and"), $.type_binding),
+        sep1("and", $.type_binding),
       ),
 
     type_binding: ($) =>
@@ -418,7 +418,7 @@ module.exports = grammar({
       seq(
         choice("export", "let"),
         optional("rec"),
-        sep1(seq(repeat($._newline), "and"), $.let_binding),
+        sep1("and", $.let_binding),
       ),
 
     let_binding: ($) =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -782,20 +782,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SYMBOL",
-                          "name": "_newline"
-                        }
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "and"
-                      }
-                    ]
+                    "type": "STRING",
+                    "value": "and"
                   },
                   {
                     "type": "SYMBOL",
@@ -2227,20 +2215,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "REPEAT",
-                        "content": {
-                          "type": "SYMBOL",
-                          "name": "_newline"
-                        }
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "and"
-                      }
-                    ]
+                    "type": "STRING",
+                    "value": "and"
                   },
                   {
                     "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -94,6 +94,22 @@
         }
       ]
     },
+    "_switch_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_statement"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "statement"
+        }
+      ]
+    },
     "statement": {
       "type": "CHOICE",
       "members": [
@@ -3421,8 +3437,20 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "switch_match"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "switch_match"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_statement_delimeter"
+                }
+              }
+            ]
           }
         },
         {
@@ -3481,7 +3509,7 @@
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
-                "name": "_one_or_more_statements"
+                "name": "_switch_body"
               },
               "named": true,
               "value": "sequence_expression"
@@ -3585,8 +3613,20 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "switch_match"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "switch_match"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_statement_delimeter"
+                }
+              }
+            ]
           }
         },
         {
@@ -9050,6 +9090,10 @@
     [
       "_statement",
       "_one_or_more_statements"
+    ],
+    [
+      "_statement",
+      "_switch_body"
     ],
     [
       "_inline_type",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -75,63 +75,27 @@ static void scan_whitespace(TSLexer *lexer, bool skip) {
   }
 }
 
-// Tries to skip a comment (line or block) starting at the current position.
-// Returns true if a comment was consumed. All characters are skipped
-// (advance with skip=true) so they are not included in any token.
-static bool skip_comment(TSLexer *lexer) {
+// Tries to skip a line comment (//) starting at the current position.
+// Returns true if a line comment was consumed. Block comments are intentionally
+// NOT handled here: they are external tokens that must be left for the
+// BLOCK_COMMENT scanner handler.
+static bool skip_line_comment(TSLexer *lexer) {
   if (lexer->lookahead != '/') return false;
-  skip(lexer);
-  switch (lexer->lookahead) {
-    case '/':
-      // Single-line comment
-      while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
-        skip(lexer);
-      }
-      return true;
-
-    case '*':
-      // Multi-line block comment (may be nested)
-      // Rewind conceptually: we already skipped the leading '/', now handle '/*'.
-      // We advance past '*' and the body.
-      skip(lexer);
-      {
-        int level = 1;
-        while (level > 0 && !lexer->eof(lexer)) {
-          switch (lexer->lookahead) {
-            case '/':
-              skip(lexer);
-              if (lexer->lookahead == '*') {
-                ++level;
-                skip(lexer);
-              }
-              break;
-            case '*':
-              skip(lexer);
-              if (lexer->lookahead == '/') {
-                --level;
-                skip(lexer);
-              }
-              break;
-            default:
-              skip(lexer);
-          }
-        }
-      }
-      return true;
-
-    default:
-      // Not a comment after `/` — bail out.
-      return false;
+  skip(lexer);  // advance past first '/'
+  if (lexer->lookahead != '/') return false;  // not a line comment
+  while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
+    skip(lexer);
   }
+  return true;
 }
 
-// Skip whitespace and comments (line and block), all as skip=true.
-// Used for peek-ahead only: none of the consumed characters will be part
-// of any emitted token.
-static void skip_whitespace_and_comments(TSLexer *lexer) {
+// Skip whitespace and line comments only, all as skip=true.
+// Used for NEWLINE peek-ahead: block comments are external tokens and must
+// not be consumed here, otherwise the BLOCK_COMMENT handler never fires.
+static void skip_whitespace_and_line_comments(TSLexer *lexer) {
   while (!lexer->eof(lexer)) {
     scan_whitespace(lexer, true);
-    if (!skip_comment(lexer)) break;
+    if (!skip_line_comment(lexer)) break;
   }
 }
 
@@ -194,9 +158,11 @@ bool tree_sitter_rescript_external_scanner_scan(
     lexer->advance(lexer, true);
     lexer->mark_end(lexer);
 
-    // Peek past whitespace and any comments to determine whether the next
+    // Peek past whitespace and line comments to determine whether the next
     // meaningful character continues the current statement.
-    skip_whitespace_and_comments(lexer);
+    // Block comments are NOT skipped here: they are external tokens and must
+    // be left for the BLOCK_COMMENT handler in a subsequent scanner call.
+    skip_whitespace_and_line_comments(lexer);
 
     bool in_multiline_statement = false;
     if (lexer->lookahead == '-') {

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -43,6 +43,14 @@ switch foo {
 | 2 => 2
 }
 
+switch l {
+| "a" => letterAll
+/* | "b" => [||] */
+/* | "g" => [||] */
+/* | "h" => [||] */
+/* | "i" => [||] */
+}
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -100,4 +108,17 @@ switch foo {
         (number)
         (sequence_expression
           (expression_statement
-            (number)))))))
+            (number))))))
+  (expression_statement
+    (switch_expression
+      (value_identifier)
+      (switch_match
+        (string
+          (string_fragment))
+        (sequence_expression
+          (expression_statement
+            (value_identifier))))
+      (block_comment)
+      (block_comment)
+      (block_comment)
+      (block_comment))))

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -37,6 +37,12 @@ switch foo {
 // in-switch
 }
 
+switch foo {
+| 1 => 1
+/* block comment in switch */
+| 2 => 2
+}
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -80,4 +86,18 @@ switch foo {
         (sequence_expression
           (expression_statement
             (number))))
-      (line_comment))))
+      (line_comment)))
+  (expression_statement
+    (switch_expression
+      (value_identifier)
+      (switch_match
+        (number)
+        (sequence_expression
+          (expression_statement
+            (number))))
+      (block_comment)
+      (switch_match
+        (number)
+        (sequence_expression
+          (expression_statement
+            (number)))))))


### PR DESCRIPTION
The NEWLINE handler's peek-ahead used skip_whitespace_and_comments, which consumed block comments as skipped characters. When it decided not to emit NEWLINE (e.g. because } follows the comment), the scanner returned false and all advances rolled back. The internal tokenizer then tokenized the leading / of /* as a standalone slash, leaving the block comment unrecognized.

Fix: replace skip_whitespace_and_comments with skip_whitespace_and_line_comments in the NEWLINE peek path. Block comments (/* */) are external tokens and must not be consumed during peek — only line comments (//) are skipped. When the peek now stops at /*, no continuation pattern matches, so NEWLINE is emitted and the next scanner call correctly handles /* as BLOCK_COMMENT.