### PR TITLE
Fix module packs in unpack expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -218,6 +218,7 @@ export default grammar({
             optional($.module_type_annotation),
           ),
           seq($.call_expression, optional($.module_type_annotation)),
+          seq($.module_pack, optional($.module_type_annotation)),
           $.extension_expression,
         ),
         ")",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -516,6 +516,27 @@
               ]
             },
             {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "module_pack"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "module_type_annotation"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "SYMBOL",
               "name": "extension_expression"
             }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2849,6 +2849,10 @@
           "named": true
         },
         {
+          "type": "module_pack",
+          "named": true
+        },
+        {
           "type": "module_type_annotation",
           "named": true
         },

--- a/test/corpus/modules.txt
+++ b/test/corpus/modules.txt
@@ -245,6 +245,8 @@ module(
 )
 module(SomeFunctor(unpack(x)))
 
+module M = unpack(module(Cleanup): PipelineStep with type state = t)
+
 module T = unpack(foo: T)
 
 module S = unpack(foo: T with type t = a)
@@ -288,6 +290,18 @@ module T3 = unpack(make(): T with type t = int)
         (arguments
           (module_unpack
             (value_identifier))))))
+  (module_declaration
+    (module_binding
+      (module_identifier)
+      (module_unpack
+        (module_pack
+          (module_identifier))
+        (module_type_annotation
+          (module_type_constraint
+            (module_identifier)
+            (constrain_type
+              (type_identifier)
+              (type_identifier)))))))
   (module_declaration
     (module_binding
       (module_identifier)


### PR DESCRIPTION
Allow first-class module packs with module type annotations inside unpack expressions, e.g. `unpack(module(Cleanup): PipelineStep with type state = t)`.

Fixes https://github.com/rescript-lang/tree-sitter-rescript/issues/288