### PR TITLE
Add linting and formatting checks for the grammar

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -44,3 +44,7 @@ indent_size = 2
 
 [{alloc,array,parser}.h]
 indent_size = 2
+
+[test/**.txt]
+indent_size = 2
+indent_style = space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         os: [ubuntu-latest, windows-2022, macos-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v2
         with:
-          tree-sitter-ref: v0.26.10
+          tree-sitter-ref: v0.26.11
 
       - name: Run tests
         uses: tree-sitter/parser-test-action@v3
@@ -34,7 +34,7 @@ jobs:
           test-python: true
           test-go: true
 
-      - name: Run test wild
+      - name: Run tests wild
         if: runner.os != 'Windows'
         continue-on-error: true
         run: node scripts/test_wild.mjs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,18 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
-      # Instruct a C++ compiler to use the C++20 standard
-      # Required to install tree-sitter dev dependencie
-      # See # https://github.com/tree-sitter/node-tree-sitter/issues/268
       - name: Install dependencies
-        run: CXXFLAGS="-std=c++20" npm ci
+        run: npm ci
 
       - name: Build WASM
         run: npx tree-sitter build --wasm
@@ -43,10 +40,10 @@ jobs:
           sed -i 's|LANGUAGE_BASE_URL = ""|LANGUAGE_BASE_URL = "/tree-sitter-rescript"|' ./public/index.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - grammar.js
+  pull_request:
+    paths:
+      - grammar.js
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Install modules
+        run: npm ci
+      - name: Run ESLint
+        run: npm run lint
+      - name: Checkformat
+        run: npm run checkformat
+      - name: Generate parser
+        run: npm run generate
+      - name: Check for diffs in parse files
+        run: git diff --exit-code

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
-v24.11.1
+# Using v22 due https://github.com/tree-sitter/node-tree-sitter/issues/268
+v22

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,5 @@
+import treesitter from 'eslint-config-treesitter';
+
+export default [
+  ...treesitter,
+];

--- a/grammar.js
+++ b/grammar.js
@@ -1448,6 +1448,7 @@ export default grammar({
 });
 
 /**
+ * Creates a rule that matches one or more rules separated by vertical bars.
  *
  * @param {Rule} rule
  *
@@ -1458,6 +1459,7 @@ function barSep1(rule) {
 }
 
 /**
+ * Creates a rule that matches one or more rules separated by commas.
  *
  * @param {Rule} rule
  *
@@ -1468,6 +1470,7 @@ function commaSep1(rule) {
 }
 
 /**
+ * Creates a rule that matches two or more rules separated by commas.
  *
  * @param {Rule} rule
  *
@@ -1478,6 +1481,7 @@ function commaSep2(rule) {
 }
 
 /**
+ * Creates a comma-separated list with at least one rule and an optional trailing comma.
  *
  * @param {Rule} rule
  *
@@ -1488,6 +1492,7 @@ function commaSep1t(rule) {
 }
 
 /**
+ * Creates a comma-separated list with at least two rules and an optional trailing comma.
  *
  * @param {Rule} rule
  *
@@ -1498,6 +1503,7 @@ function commaSep2t(rule) {
 }
 
 /**
+ * Creates an optional comma-separated list with an optional trailing comma.
  *
  * @param {Rule} rule
  *
@@ -1508,6 +1514,7 @@ function commaSept(rule) {
 }
 
 /**
+ * Creates a rule that matches one or more rules separated by a delimiter.
  *
  * @param {string} delimiter
  * @param {Rule} rule
@@ -1519,6 +1526,7 @@ function sep1(delimiter, rule) {
 }
 
 /**
+ * Creates a rule that matches a final rule with an optional dotted prefix.
  *
  * @param {Rule} prefix
  * @param {Rule} final
@@ -1530,6 +1538,7 @@ function path(prefix, final) {
 }
 
 /**
+ * Creates a rule enclosed in parentheses.
  *
  * @param {Rule} rule
  *

--- a/grammar.js
+++ b/grammar.js
@@ -171,7 +171,7 @@ export default grammar({
         $.expression_statement,
         $.declaration,
         $.open_statement,
-        $.include_statement
+        $.include_statement,
       ),
 
     block: ($) =>
@@ -182,7 +182,7 @@ export default grammar({
     include_statement: ($) =>
       seq(
         'include',
-        choice($._module_definition, parenthesize($._module_structure))
+        choice($._module_definition, parenthesize($._module_structure)),
       ),
 
     declaration: ($) =>
@@ -191,7 +191,7 @@ export default grammar({
         $.let_declaration,
         $.module_declaration,
         $.external_declaration,
-        $.exception_declaration
+        $.exception_declaration,
       ),
 
     module_binding: ($) =>
@@ -203,18 +203,18 @@ export default grammar({
               ':',
               field(
                 'signature',
-                choice($.block, $.module_expression, $.functor)
-              )
-            )
+                choice($.block, $.module_expression, $.functor),
+              ),
+            ),
           ),
           optional(
             seq(
               '=',
               optional('await'),
-              field('definition', $._module_definition)
-            )
-          )
-        )
+              field('definition', $._module_definition),
+            ),
+          ),
+        ),
       ),
 
     module_declaration: ($) =>
@@ -222,7 +222,7 @@ export default grammar({
         'module',
         optional('rec'),
         optional('type'),
-        sep1('and', $.module_binding)
+        sep1('and', $.module_binding),
       ),
 
     _module_structure: ($) =>
@@ -240,15 +240,15 @@ export default grammar({
             choice(
               $.value_identifier,
               $.value_identifier_path,
-              $.member_expression
+              $.member_expression,
             ),
-            optional($.module_type_annotation)
+            optional($.module_type_annotation),
           ),
           seq($.call_expression, optional($.module_type_annotation)),
           seq($.module_pack, optional($.module_type_annotation)),
-          $.extension_expression
+          $.extension_expression,
         ),
-        ')'
+        ')',
       ),
 
     functor: ($) =>
@@ -256,7 +256,7 @@ export default grammar({
         field('parameters', $.functor_parameters),
         optional(field('return_module_type', $.module_type_annotation)),
         '=>',
-        field('body', $._module_definition)
+        field('body', $._module_definition),
       ),
 
     functor_parameters: ($) =>
@@ -277,8 +277,8 @@ export default grammar({
         $.variant_identifier,
         optional($.variant_parameters),
         optional(
-          seq('=', choice($.variant_identifier, $.nested_variant_identifier))
-        )
+          seq('=', choice($.variant_identifier, $.nested_variant_identifier)),
+        ),
       ),
 
     type_declaration: ($) =>
@@ -286,7 +286,7 @@ export default grammar({
         optional('export'),
         'type',
         optional('rec'),
-        sep1('and', $.type_binding)
+        sep1('and', $.type_binding),
       ),
 
     type_binding: ($) =>
@@ -302,13 +302,13 @@ export default grammar({
                 seq(
                   choice('=', '+='),
                   optional('private'),
-                  field('body', $._type)
-                )
+                  field('body', $._type),
+                ),
               ),
-              repeat($.type_constraint)
-            )
-          )
-        )
+              repeat($.type_constraint),
+            ),
+          ),
+        ),
       ),
 
     extensible_type: (_$) => '..',
@@ -317,7 +317,7 @@ export default grammar({
       seq(
         '<',
         commaSep1t(seq(optional(choice('+', '-')), $.type_identifier)),
-        '>'
+        '>',
       ),
 
     type_annotation: ($) => seq(':', $._inline_type),
@@ -339,14 +339,14 @@ export default grammar({
         $.module_pack,
         $.unit,
         $.polymorphic_type,
-        alias($._as_aliasing_non_function_inline_type, $.as_aliasing_type)
+        alias($._as_aliasing_non_function_inline_type, $.as_aliasing_type),
       ),
 
     polymorphic_type: ($) =>
       seq(
         choice(repeat1($.type_identifier), $.abstract_type),
         '.',
-        $._inline_type
+        $._inline_type,
       ),
 
     type_constraint: ($) => seq('constraint', $._type, '=', $._type),
@@ -357,8 +357,8 @@ export default grammar({
       prec.left(
         seq(
           optional('|'),
-          barSep1(choice($.variant_declaration, $.variant_type_spread))
-        )
+          barSep1(choice($.variant_declaration, $.variant_type_spread)),
+        ),
       ),
 
     variant_declaration: ($) =>
@@ -366,8 +366,8 @@ export default grammar({
         seq(
           $.variant_identifier,
           optional($.variant_parameters),
-          optional($.type_annotation)
-        )
+          optional($.type_annotation),
+        ),
       ),
 
     variant_type_spread: ($) => seq('...', $._type_identifier),
@@ -380,16 +380,16 @@ export default grammar({
           choice('[', '[>', '[<'),
           optional('|'),
           barSep1($.polyvar_declaration),
-          ']'
-        )
+          ']',
+        ),
       ),
 
     polyvar_declaration: ($) =>
       prec.right(
         choice(
           seq($.polyvar_identifier, optional($.polyvar_parameters)),
-          $._inline_type
-        )
+          $._inline_type,
+        ),
       ),
 
     polyvar_parameters: ($) => seq('(', commaSep1t($._type), ')'),
@@ -401,13 +401,13 @@ export default grammar({
         optional('mutable'),
         alias($.value_identifier, $.property_identifier),
         optional('?'),
-        $.type_annotation
+        $.type_annotation,
       ),
 
     type_spread: ($) =>
       seq(
         '...',
-        choice($.type_identifier, $.generic_type, $.type_identifier_path)
+        choice($.type_identifier, $.generic_type, $.type_identifier_path),
       ),
 
     _record_type_member: ($) => choice($.record_type_field, $.type_spread),
@@ -419,10 +419,10 @@ export default grammar({
           choice(
             commaSep1t($._object_type_member),
             seq('.', commaSept($._object_type_member)),
-            seq('..', commaSept($._object_type_member))
+            seq('..', commaSept($._object_type_member)),
           ),
-          '}'
-        )
+          '}',
+        ),
       ),
 
     _object_type_member: ($) =>
@@ -447,7 +447,7 @@ export default grammar({
     function_type_parameter: ($) =>
       seq(
         optional($.uncurry),
-        choice($._type, seq($.uncurry, $._type), $.labeled_parameter)
+        choice($._type, seq($.uncurry, $._type), $.labeled_parameter),
       ),
 
     let_declaration: ($) =>
@@ -459,10 +459,10 @@ export default grammar({
         choice(
           seq(
             $.type_annotation,
-            optional(seq('=', field('body', $.expression)))
+            optional(seq('=', field('body', $.expression))),
           ),
-          seq('=', field('body', $.expression))
-        )
+          seq('=', field('body', $.expression)),
+        ),
       ),
 
     expression_statement: ($) => $.expression,
@@ -481,7 +481,7 @@ export default grammar({
         $.mutation_expression,
         $.await_expression,
         $.block,
-        $.assert_expression
+        $.assert_expression,
       ),
 
     primary_expression: ($) =>
@@ -516,7 +516,7 @@ export default grammar({
         $.extension_expression,
         $.lazy_expression,
         $._jsx_element,
-        $.regex
+        $.regex,
       ),
 
     parenthesized_expression: ($) =>
@@ -531,11 +531,11 @@ export default grammar({
           optional('async'),
           choice(
             field('parameter', $.value_identifier),
-            $._definition_signature
+            $._definition_signature,
           ),
           '=>',
-          field('body', $.expression)
-        )
+          field('body', $.expression),
+        ),
       ),
 
     record: ($) =>
@@ -544,16 +544,16 @@ export default grammar({
         choice(
           $._record_single_field,
           $._record_single_pun_field,
-          commaSep2t($._record_element)
+          commaSep2t($._record_element),
         ),
-        '}'
+        '}',
       ),
 
     _record_element: ($) =>
       choice(
         $.spread_element,
         $.record_field,
-        alias($._record_pun_field, $.record_field)
+        alias($._record_pun_field, $.record_field),
       ),
 
     record_field: ($) =>
@@ -569,7 +569,7 @@ export default grammar({
     _record_field_name: ($) =>
       choice(
         alias($.value_identifier, $.property_identifier),
-        alias($.value_identifier_path, $.property_identifier)
+        alias($.value_identifier_path, $.property_identifier),
       ),
 
     object: ($) =>
@@ -578,9 +578,9 @@ export default grammar({
         choice(
           commaSep1t($._object_field),
           seq('.', commaSept($._object_field)),
-          seq('..', commaSept($._object_field))
+          seq('..', commaSept($._object_field)),
         ),
-        '}'
+        '}',
       ),
 
     _object_field: ($) => alias($.object_field, $.field),
@@ -603,7 +603,7 @@ export default grammar({
         alias($._dict_constructor, 'dict'),
         '{',
         commaSept($.dict_entry),
-        '}'
+        '}',
       ),
 
     dict_entry: ($) => seq($.string, ':', $.expression),
@@ -614,7 +614,7 @@ export default grammar({
         $.expression,
         $.block,
         repeat($.else_if_clause),
-        optional($.else_clause)
+        optional($.else_clause),
       ),
 
     else_if_clause: ($) => seq('else', 'if', $.expression, $.block),
@@ -627,7 +627,7 @@ export default grammar({
         $.expression,
         '{',
         repeat(seq($.switch_match, optional($._semicolon))),
-        '}'
+        '}',
       ),
 
     switch_match: ($) =>
@@ -638,8 +638,8 @@ export default grammar({
           field('pattern', choice($.variant_spread_pattern, $._pattern)),
           optional($.guard),
           '=>',
-          field('body', alias($._switch_body, $.sequence_expression))
-        )
+          field('body', alias($._switch_body, $.sequence_expression)),
+        ),
       ),
 
     guard: ($) => seq(choice('if', 'when'), $.expression),
@@ -658,7 +658,7 @@ export default grammar({
         'catch',
         '{',
         repeat(seq($.switch_match, optional($._semicolon))),
-        '}'
+        '}',
       ),
 
     as_aliasing: ($) =>
@@ -676,8 +676,8 @@ export default grammar({
         'call',
         seq(
           field('function', $.primary_expression),
-          field('arguments', alias($.call_arguments, $.arguments))
-        )
+          field('arguments', alias($.call_arguments, $.arguments)),
+        ),
       ),
 
     pipe_expression: ($) =>
@@ -685,14 +685,14 @@ export default grammar({
         seq(
           choice($.primary_expression, $.block),
           choice('->', '|>'),
-          choice($.primary_expression, $.block)
-        )
+          choice($.primary_expression, $.block),
+        ),
       ),
 
     module_pack: ($) =>
       seq(
         'module',
-        parenthesize(choice($._module_structure, $.type_identifier_path))
+        parenthesize(choice($._module_structure, $.type_identifier_path)),
       ),
 
     call_arguments: ($) =>
@@ -701,13 +701,13 @@ export default grammar({
         optional($.uncurry),
         optional(commaSep1t($._call_argument)),
         optional($.partial_application_spread),
-        ')'
+        ')',
       ),
 
     _call_argument: ($) =>
       choice(
         seq($.expression, optional($.type_annotation)),
-        $.labeled_argument
+        $.labeled_argument,
       ),
 
     partial_application_spread: ($) => '...',
@@ -723,10 +723,10 @@ export default grammar({
               '=',
               optional('?'),
               field('value', $.expression),
-              optional(field('type', $.type_annotation))
-            )
-          )
-        )
+              optional(field('type', $.type_annotation)),
+            ),
+          ),
+        ),
       ),
 
     _definition_signature: ($) =>
@@ -735,9 +735,9 @@ export default grammar({
         optional(
           field(
             'return_type',
-            alias($._return_type_annotation, $.type_annotation)
-          )
-        )
+            alias($._return_type_annotation, $.type_annotation),
+          ),
+        ),
       ),
 
     _return_type_annotation: ($) => seq(':', $._non_function_inline_type),
@@ -752,8 +752,8 @@ export default grammar({
           seq($._pattern, optional($.type_annotation)),
           $.labeled_parameter,
           $.unit,
-          $.abstract_type
-        )
+          $.abstract_type,
+        ),
       ),
 
     labeled_parameter: ($) =>
@@ -766,15 +766,15 @@ export default grammar({
             seq(
               $.type_annotation,
               optional(
-                field('default_value', $._labeled_parameter_default_value)
-              )
+                field('default_value', $._labeled_parameter_default_value),
+              ),
             ),
             seq(
               field('default_value', $._labeled_parameter_default_value),
-              optional($.type_annotation)
-            )
-          )
-        )
+              optional($.type_annotation),
+            ),
+          ),
+        ),
       ),
 
     abstract_type: ($) => seq('type', repeat1($.type_identifier)),
@@ -800,10 +800,10 @@ export default grammar({
             $.parenthesized_pattern,
             $.or_pattern,
             $.range_pattern,
-            $.exception_pattern
+            $.exception_pattern,
           ),
-          optional($.as_aliasing)
-        )
+          optional($.as_aliasing),
+        ),
       ),
 
     parenthesized_pattern: ($) =>
@@ -823,7 +823,7 @@ export default grammar({
         $.tuple_pattern,
         $.array_pattern,
         $.list_pattern,
-        $.dict_pattern
+        $.dict_pattern,
       ),
 
     _literal_pattern: ($) =>
@@ -834,14 +834,14 @@ export default grammar({
         $.number,
         $.true,
         $.false,
-        $.regex
+        $.regex,
       ),
 
     variant_pattern: ($) =>
       seq(
         optional('?'),
         choice($.variant_identifier, $.nested_variant_identifier),
-        optional(alias($._variant_pattern_parameters, $.formal_parameters))
+        optional(alias($._variant_pattern_parameters, $.formal_parameters)),
       ),
 
     _variant_pattern_parameters: ($) =>
@@ -853,7 +853,7 @@ export default grammar({
     polyvar_pattern: ($) =>
       seq(
         $.polyvar_identifier,
-        optional(alias($._variant_pattern_parameters, $.formal_parameters))
+        optional(alias($._variant_pattern_parameters, $.formal_parameters)),
       ),
 
     record_pattern: ($) =>
@@ -863,10 +863,10 @@ export default grammar({
           seq(
             optional('?'),
             choice($.value_identifier, $.value_identifier_path),
-            optional(seq(':', $._pattern))
-          )
+            optional(seq(':', $._pattern)),
+          ),
         ),
-        '}'
+        '}',
       ),
 
     tuple_item_pattern: ($) => seq($._pattern, optional($.type_annotation)),
@@ -881,7 +881,7 @@ export default grammar({
         $._list_constructor,
         '{',
         optional(commaSep1t($._collection_element_pattern)),
-        '}'
+        '}',
       ),
 
     dict_pattern: ($) =>
@@ -889,7 +889,7 @@ export default grammar({
         alias($._dict_constructor, 'dict'),
         '{',
         commaSept($.dict_pattern_entry),
-        '}'
+        '}',
       ),
 
     dict_pattern_entry: ($) => seq($.string, ':', $._pattern),
@@ -908,7 +908,7 @@ export default grammar({
       seq(
         field('open_tag', $.jsx_opening_element),
         repeat($._jsx_child),
-        field('close_tag', $.jsx_closing_element)
+        field('close_tag', $.jsx_closing_element),
       ),
 
     jsx_fragment: ($) => seq('<', '>', repeat($._jsx_child), '<', '/', '>'),
@@ -917,7 +917,7 @@ export default grammar({
       seq(
         '{',
         optional(choice($._one_or_more_statements, $.spread_element)),
-        '}'
+        '}',
       ),
 
     _jsx_child: ($) =>
@@ -932,7 +932,7 @@ export default grammar({
         $.jsx_fragment,
         $.block,
         $.spread_element,
-        $.member_expression
+        $.member_expression,
       ),
 
     jsx_opening_element: ($) =>
@@ -942,8 +942,8 @@ export default grammar({
           '<',
           field('name', $._jsx_element_name),
           repeat(field('attribute', $._jsx_attribute)),
-          '>'
-        )
+          '>',
+        ),
       ),
 
     _jsx_identifier: ($) =>
@@ -955,8 +955,8 @@ export default grammar({
         seq(
           choice($._jsx_identifier, $.nested_jsx_identifier),
           '.',
-          $._jsx_identifier
-        )
+          $._jsx_identifier,
+        ),
       ),
 
     _jsx_element_name: ($) =>
@@ -971,7 +971,7 @@ export default grammar({
         field('name', $._jsx_element_name),
         repeat(field('attribute', $._jsx_attribute)),
         '/',
-        '>'
+        '>',
       ),
 
     _jsx_attribute_name: ($) =>
@@ -983,7 +983,7 @@ export default grammar({
       seq(
         optional('?'),
         $._jsx_attribute_name,
-        optional(seq('=', optional('?'), $._jsx_attribute_value))
+        optional(seq('=', optional('?'), $._jsx_attribute_value)),
       ),
 
     _jsx_attribute_value: ($) => choice($.primary_expression, $.jsx_expression),
@@ -999,7 +999,7 @@ export default grammar({
     decorator: ($) =>
       choice(
         alias($._decorator_inline, $.decorator_identifier),
-        seq(alias($._decorator, $.decorator_identifier), $.decorator_arguments)
+        seq(alias($._decorator, $.decorator_identifier), $.decorator_arguments),
       ),
 
     decorator_arguments: ($) =>
@@ -1012,8 +1012,8 @@ export default grammar({
           field('object', $.primary_expression),
           '[',
           field('index', $.expression),
-          ']'
-        )
+          ']',
+        ),
       ),
 
     member_expression: ($) =>
@@ -1026,13 +1026,13 @@ export default grammar({
             seq(
               field(
                 'module',
-                seq(repeat(seq($.module_identifier, '.')), $.module_identifier)
+                seq(repeat(seq($.module_identifier, '.')), $.module_identifier),
               ),
-              '.'
-            )
+              '.',
+            ),
           ),
-          field('property', alias($.value_identifier, $.property_identifier))
-        )
+          field('property', alias($.value_identifier, $.property_identifier)),
+        ),
       ),
 
     spread_element: ($) => seq('...', $.expression),
@@ -1044,8 +1044,8 @@ export default grammar({
           '?',
           field('consequence', $.expression),
           ':',
-          field('alternative', $.expression)
-        )
+          field('alternative', $.expression),
+        ),
       ),
 
     for_expression: ($) =>
@@ -1056,7 +1056,7 @@ export default grammar({
         $.expression,
         choice('to', 'downto'),
         $.expression,
-        $.block
+        $.block,
       ),
 
     while_expression: ($) => seq('while', $.expression, $.block),
@@ -1099,10 +1099,10 @@ export default grammar({
             seq(
               field('left', $.expression),
               field('operator', operator),
-              field('right', $.expression)
-            )
-          )
-        )
+              field('right', $.expression),
+            ),
+          ),
+        ),
       ),
 
     coercion_expression: ($) =>
@@ -1112,7 +1112,7 @@ export default grammar({
           seq(
             field('left', $.expression),
             field('operator', ':>'),
-            field('right', $._type)
+            field('right', $._type),
           ),
           seq(
             '(',
@@ -1120,9 +1120,9 @@ export default grammar({
             field('source_type', $.type_annotation),
             field('operator', ':>'),
             field('right', $._type),
-            ')'
-          )
-        )
+            ')',
+          ),
+        ),
       ),
 
     unary_expression: ($) =>
@@ -1137,9 +1137,9 @@ export default grammar({
         ].map(([operator, precedence]) =>
           prec.left(
             precedence,
-            seq(field('operator', operator), field('argument', $.expression))
-          )
-        )
+            seq(field('operator', operator), field('argument', $.expression)),
+          ),
+        ),
       ),
 
     extension_expression: ($) =>
@@ -1147,8 +1147,8 @@ export default grammar({
         seq(
           repeat1('%'),
           $.extension_identifier,
-          optional($._extension_expression_payload)
-        )
+          optional($._extension_expression_payload),
+        ),
       ),
 
     _extension_expression_payload: ($) =>
@@ -1158,8 +1158,8 @@ export default grammar({
       prec.right(
         seq(
           choice($.variant_identifier, $.nested_variant_identifier),
-          optional(alias($.variant_arguments, $.arguments))
-        )
+          optional(alias($.variant_arguments, $.arguments)),
+        ),
       ),
 
     nested_variant_identifier: ($) =>
@@ -1172,8 +1172,8 @@ export default grammar({
       prec.right(
         seq(
           $.polyvar_identifier,
-          optional(alias($.variant_arguments, $.arguments))
-        )
+          optional(alias($.variant_arguments, $.arguments)),
+        ),
       ),
 
     _type_identifier: ($) => choice($.type_identifier, $.type_identifier_path),
@@ -1185,7 +1185,7 @@ export default grammar({
       choice(
         $.module_primary_expression,
         $.module_type_of,
-        $.module_type_constraint
+        $.module_type_constraint,
       ),
 
     module_primary_expression: ($) =>
@@ -1194,7 +1194,7 @@ export default grammar({
         $.module_identifier,
         $.module_identifier_path,
         $.functor_use,
-        $.module_unpack
+        $.module_unpack,
       ),
 
     parenthesized_module_expression: ($) =>
@@ -1205,7 +1205,7 @@ export default grammar({
 
     module_type_of: ($) =>
       prec.left(
-        seq('module', 'type', 'of', choice($.module_expression, $.block))
+        seq('module', 'type', 'of', choice($.module_expression, $.block)),
       ),
 
     _module_type_constraint_with: ($) =>
@@ -1214,9 +1214,9 @@ export default grammar({
           'with',
           sep1(
             choice('and', 'with'),
-            choice($.constrain_module, $.constrain_type)
-          )
-        )
+            choice($.constrain_module, $.constrain_type),
+          ),
+        ),
       ),
 
     module_type_constraint: ($) =>
@@ -1228,9 +1228,9 @@ export default grammar({
             $.module_expression,
             $._module_type_constraint_with,
             ')',
-            $._module_type_constraint_with
-          )
-        )
+            $._module_type_constraint_with,
+          ),
+        ),
       ),
 
     constrain_module: ($) =>
@@ -1238,7 +1238,7 @@ export default grammar({
         'module',
         $.module_primary_expression,
         choice('=', ':='),
-        $.module_primary_expression
+        $.module_primary_expression,
       ),
 
     constrain_type: ($) =>
@@ -1259,8 +1259,8 @@ export default grammar({
         '#',
         choice(
           /[a-zA-Z0-9_']+/,
-          seq(optional('\\'), alias($.string, $.polyvar_string))
-        )
+          seq(optional('\\'), alias($.string, $.polyvar_string)),
+        ),
       ),
 
     type_identifier: ($) =>
@@ -1282,7 +1282,7 @@ export default grammar({
         '/',
         field('pattern', $.regex_pattern),
         token.immediate(prec(1, '/')),
-        optional(field('flags', $.regex_flags))
+        optional(field('flags', $.regex_flags)),
       ),
 
     regex_pattern: (_) =>
@@ -1293,10 +1293,10 @@ export default grammar({
             choice(
               seq('[', repeat(choice(seq('\\', /./), /[^\]\n\\]/)), ']'),
               seq('\\', /./),
-              /[^/\\\[\n]/
-            )
-          )
-        )
+              /[^/\\\[\n]/,
+            ),
+          ),
+        ),
       ),
 
     regex_flags: (_) => token.immediate(/[a-z]+/),
@@ -1305,27 +1305,27 @@ export default grammar({
       // OCaml: https://github.com/tree-sitter/tree-sitter-ocaml/blob/f1106bf834703f1f2f795da1a3b5f8f40174ffcc/ocaml/grammar.js#L26
       const hex_literal = seq(
         optional(choice('-', '+')),
-        /0[xX][0-9A-Fa-f][0-9A-Fa-f_]*(\.[0-9A-Fa-f_]*)?([pP][+\-]?[0-9][0-9_]*)?[g-zG-Z]?/
-      )
+        /0[xX][0-9A-Fa-f][0-9A-Fa-f_]*(\.[0-9A-Fa-f_]*)?([pP][+\-]?[0-9][0-9_]*)?[g-zG-Z]?/,
+      );
 
-      const decimal_digits = /\d(_?\d)*/
-      const signed_integer = seq(optional(choice('-', '+')), decimal_digits)
-      const exponent_part = seq(choice('e', 'E'), signed_integer)
+      const decimal_digits = /\d(_?\d)*/;
+      const signed_integer = seq(optional(choice('-', '+')), decimal_digits);
+      const exponent_part = seq(choice('e', 'E'), signed_integer);
 
-      const binary_literal = seq(choice('0b', '0B'), /[0-1](_?[0-1])*/)
+      const binary_literal = seq(choice('0b', '0B'), /[0-1](_?[0-1])*/);
 
-      const octal_literal = seq(choice('0o', '0O'), /[0-7](_?[0-7])*/)
+      const octal_literal = seq(choice('0o', '0O'), /[0-7](_?[0-7])*/);
 
       const bigint_literal = seq(
         optional(choice('-', '+')),
         choice(hex_literal, binary_literal, octal_literal, decimal_digits),
-        'n'
-      )
+        'n',
+      );
 
       const decimal_integer_literal = choice(
         repeat1('0'),
-        seq(repeat('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits)))
-      )
+        seq(repeat('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits))),
+      );
 
       const decimal_literal = seq(
         optional(choice('-', '+')),
@@ -1334,13 +1334,13 @@ export default grammar({
             decimal_integer_literal,
             '.',
             optional(decimal_digits),
-            optional(exponent_part)
+            optional(exponent_part),
           ),
           seq('.', decimal_digits, optional(exponent_part)),
           seq(decimal_integer_literal, exponent_part),
-          decimal_digits
-        )
-      )
+          decimal_digits,
+        ),
+      );
 
       const int_32_64 = seq(
         optional(choice('-', '+')),
@@ -1348,10 +1348,10 @@ export default grammar({
           decimal_integer_literal,
           binary_literal,
           octal_literal,
-          hex_literal
+          hex_literal,
         ),
-        choice('L', 'l')
-      )
+        choice('L', 'l'),
+      );
 
       return token(
         choice(
@@ -1360,9 +1360,9 @@ export default grammar({
           binary_literal,
           octal_literal,
           bigint_literal,
-          int_32_64
-        )
-      )
+          int_32_64,
+        ),
+      );
     },
 
     unit: ($) => seq('(', ')'),
@@ -1377,10 +1377,10 @@ export default grammar({
         repeat(
           choice(
             alias($.unescaped_double_string_fragment, $.string_fragment),
-            $.escape_sequence
-          )
+            $.escape_sequence,
+          ),
         ),
-        '"'
+        '"',
       ),
 
     // Workaround to https://github.com/tree-sitter/tree-sitter/issues/1156
@@ -1399,9 +1399,9 @@ export default grammar({
             /[0-7]{1,3}/,
             /x[0-9a-fA-F]{2}/,
             /u[0-9a-fA-F]{4}/,
-            /u\{[0-9a-fA-F]+\}/
-          )
-        )
+            /u\{[0-9a-fA-F]+\}/,
+          ),
+        ),
       ),
 
     template_string: ($) =>
@@ -1412,14 +1412,14 @@ export default grammar({
               choice(
                 /[a-z_][a-zA-Z0-9_']*/,
                 // escape_sequence
-                seq('\\"', /[^"]+/, '"')
-              )
+                seq('\\"', /[^"]+/, '"'),
+              ),
             ),
-            '`'
-          )
+            '`',
+          ),
         ),
         optional($.template_string_content),
-        '`'
+        '`',
       ),
 
     template_string_content: ($) =>
@@ -1428,15 +1428,16 @@ export default grammar({
           $._template_chars,
           $.template_substitution,
           /\s/,
-          choice(alias('\\`', $.escape_sequence), $.escape_sequence)
-        )
+          choice(alias('\\`', $.escape_sequence), $.escape_sequence),
+        ),
       ),
 
     template_substitution: ($) =>
       choice(seq('$', $.value_identifier), seq('${', $.expression, '}')),
 
     character: ($) =>
-      seq("'", repeat(choice(/[^\\']/, $.escape_sequence)), "'"),
+      // prettier-ignore
+      seq('\'', repeat(choice(/[^\\']/, $.escape_sequence)), '\''),
 
     _unescaped_template_string_fragment: ($) =>
       token.immediate(prec(1, /[^`\\\$]+/)),
@@ -1447,7 +1448,7 @@ export default grammar({
 
     _reserved_identifier: ($) => choice('async', 'unpack'),
   },
-})
+});
 
 /**
  * Creates a rule that matches one or more rules separated by vertical bars.
@@ -1457,7 +1458,7 @@ export default grammar({
  * @returns {SeqRule}
  */
 function barSep1(rule) {
-  return seq(rule, repeat(seq('|', rule)))
+  return seq(rule, repeat(seq('|', rule)));
 }
 
 /**
@@ -1468,7 +1469,7 @@ function barSep1(rule) {
  * @returns {SeqRule}
  */
 function commaSep1(rule) {
-  return seq(rule, repeat(seq(',', rule)))
+  return seq(rule, repeat(seq(',', rule)));
 }
 
 /**
@@ -1479,7 +1480,7 @@ function commaSep1(rule) {
  * @returns {SeqRule}
  */
 function commaSep2(rule) {
-  return seq(rule, ',', commaSep1(rule))
+  return seq(rule, ',', commaSep1(rule));
 }
 
 /**
@@ -1490,7 +1491,7 @@ function commaSep2(rule) {
  * @returns {SeqRule}
  */
 function commaSep1t(rule) {
-  return seq(commaSep1(rule), optional(','))
+  return seq(commaSep1(rule), optional(','));
 }
 
 /**
@@ -1501,7 +1502,7 @@ function commaSep1t(rule) {
  * @returns {SeqRule}
  */
 function commaSep2t(rule) {
-  return seq(commaSep2(rule), optional(','))
+  return seq(commaSep2(rule), optional(','));
 }
 
 /**
@@ -1512,7 +1513,7 @@ function commaSep2t(rule) {
  * @returns {ChoiceRule}
  */
 function commaSept(rule) {
-  return optional(commaSep1t(rule))
+  return optional(commaSep1t(rule));
 }
 
 /**
@@ -1524,7 +1525,7 @@ function commaSept(rule) {
  * @returns {SeqRule}
  */
 function sep1(delimiter, rule) {
-  return seq(rule, repeat(seq(delimiter, rule)))
+  return seq(rule, repeat(seq(delimiter, rule)));
 }
 
 /**
@@ -1536,7 +1537,7 @@ function sep1(delimiter, rule) {
  * @returns {ChoiceRule}
  */
 function path(prefix, final) {
-  return choice(final, seq(prefix, '.', final))
+  return choice(final, seq(prefix, '.', final));
 }
 
 /**
@@ -1547,5 +1548,5 @@ function path(prefix, final) {
  * @returns {SeqRule}
  */
 function parenthesize(rule) {
-  return seq('(', rule, ')')
+  return seq('(', rule, ')');
 }

--- a/grammar.js
+++ b/grammar.js
@@ -1,14 +1,14 @@
 /// <reference types="tree-sitter-cli/dsl" />
 
 export default grammar({
-  name: "rescript",
+  name: 'rescript',
 
   externals: ($) => [
     $._automatic_semicolon,
     $._continuation,
     $.block_comment,
     '"',
-    "`",
+    '`',
     $._template_chars,
     $._lparen,
     $._rparen,
@@ -30,30 +30,30 @@ export default grammar({
 
   reserved: {
     global: ($) => [
-      "and",
-      "as",
-      "assert",
-      "constraint",
-      "else",
-      "exception",
-      "external",
-      "false",
-      "for",
-      "if",
-      "in",
-      "include",
-      "let",
-      "module",
-      "mutable",
-      "of",
-      "open",
-      "rec",
-      "switch",
-      "true",
-      "try",
-      "type",
-      "when",
-      "while",
+      'and',
+      'as',
+      'assert',
+      'constraint',
+      'else',
+      'exception',
+      'external',
+      'false',
+      'for',
+      'if',
+      'in',
+      'include',
+      'let',
+      'module',
+      'mutable',
+      'of',
+      'open',
+      'rec',
+      'switch',
+      'true',
+      'try',
+      'type',
+      'when',
+      'while',
     ],
   },
 
@@ -72,25 +72,25 @@ export default grammar({
   precedences: ($) => [
     // + - Operators -> precendence
     [
-      "unary_not",
-      "member",
-      "call",
+      'unary_not',
+      'member',
+      'call',
       $.spread_element,
       $.await_expression,
       $.pipe_expression,
       $.lazy_expression,
-      "binary_times",
-      "binary_pow",
-      "binary_plus",
-      "binary_shift",
-      "binary_compare",
-      "binary_relation",
-      "binary_bitand",
-      "binary_bitxor",
-      "binary_bitor",
-      "binary_and",
-      "binary_or",
-      "coercion_relation",
+      'binary_times',
+      'binary_pow',
+      'binary_plus',
+      'binary_shift',
+      'binary_compare',
+      'binary_relation',
+      'binary_bitand',
+      'binary_bitxor',
+      'binary_bitor',
+      'binary_and',
+      'binary_or',
+      'coercion_relation',
       $.expression,
       $.primary_expression,
       $.ternary_expression,
@@ -157,9 +157,9 @@ export default grammar({
 
     _statement: ($) => seq($.statement, $._semicolon),
 
-    _semicolon: ($) => choice(";", $._automatic_semicolon),
+    _semicolon: ($) => choice(';', $._automatic_semicolon),
 
-    line_comment: ($) => token(seq("//", /[^\n]*/)),
+    line_comment: ($) => token(seq('//', /[^\n]*/)),
 
     _one_or_more_statements: ($) =>
       seq(repeat($._statement), $.statement, optional($._semicolon)),
@@ -175,13 +175,13 @@ export default grammar({
       ),
 
     block: ($) =>
-      prec.right(seq("{", optional($._one_or_more_statements), "}")),
+      prec.right(seq('{', optional($._one_or_more_statements), '}')),
 
-    open_statement: ($) => seq("open", optional("!"), $.module_expression),
+    open_statement: ($) => seq('open', optional('!'), $.module_expression),
 
     include_statement: ($) =>
       seq(
-        "include",
+        'include',
         choice($._module_definition, parenthesize($._module_structure)),
       ),
 
@@ -197,21 +197,21 @@ export default grammar({
     module_binding: ($) =>
       prec.left(
         seq(
-          field("name", choice($.module_identifier, $.type_identifier)),
+          field('name', choice($.module_identifier, $.type_identifier)),
           optional(
             seq(
-              ":",
+              ':',
               field(
-                "signature",
+                'signature',
                 choice($.block, $.module_expression, $.functor),
               ),
             ),
           ),
           optional(
             seq(
-              "=",
-              optional("await"),
-              field("definition", $._module_definition),
+              '=',
+              optional('await'),
+              field('definition', $._module_definition),
             ),
           ),
         ),
@@ -219,10 +219,10 @@ export default grammar({
 
     module_declaration: ($) =>
       seq(
-        "module",
-        optional("rec"),
-        optional("type"),
-        sep1("and", $.module_binding),
+        'module',
+        optional('rec'),
+        optional('type'),
+        sep1('and', $.module_binding),
       ),
 
     _module_structure: ($) =>
@@ -233,8 +233,8 @@ export default grammar({
 
     module_unpack: ($) =>
       seq(
-        "unpack",
-        "(",
+        'unpack',
+        '(',
         choice(
           seq(
             choice(
@@ -248,61 +248,61 @@ export default grammar({
           seq($.module_pack, optional($.module_type_annotation)),
           $.extension_expression,
         ),
-        ")",
+        ')',
       ),
 
     functor: ($) =>
       seq(
-        field("parameters", $.functor_parameters),
-        optional(field("return_module_type", $.module_type_annotation)),
-        "=>",
-        field("body", $._module_definition),
+        field('parameters', $.functor_parameters),
+        optional(field('return_module_type', $.module_type_annotation)),
+        '=>',
+        field('body', $._module_definition),
       ),
 
     functor_parameters: ($) =>
-      seq("(", optional(commaSep1t($.functor_parameter)), ")"),
+      seq('(', optional(commaSep1t($.functor_parameter)), ')'),
 
     functor_parameter: ($) =>
       seq($.module_identifier, optional($.module_type_annotation)),
 
     module_type_annotation: ($) =>
-      seq(":", choice($.module_expression, $.block)),
+      seq(':', choice($.module_expression, $.block)),
 
     external_declaration: ($) =>
-      seq("external", $.value_identifier, $.type_annotation, "=", $.string),
+      seq('external', $.value_identifier, $.type_annotation, '=', $.string),
 
     exception_declaration: ($) =>
       seq(
-        "exception",
+        'exception',
         $.variant_identifier,
         optional($.variant_parameters),
         optional(
-          seq("=", choice($.variant_identifier, $.nested_variant_identifier)),
+          seq('=', choice($.variant_identifier, $.nested_variant_identifier)),
         ),
       ),
 
     type_declaration: ($) =>
       seq(
-        optional("export"),
-        "type",
-        optional("rec"),
-        sep1("and", $.type_binding),
+        optional('export'),
+        'type',
+        optional('rec'),
+        sep1('and', $.type_binding),
       ),
 
     type_binding: ($) =>
       seq(
-        field("name", choice($.type_identifier, $.type_identifier_path)),
+        field('name', choice($.type_identifier, $.type_identifier_path)),
         optional($.type_parameters),
         optional(
           choice(
-            seq("=", $.extensible_type),
+            seq('=', $.extensible_type),
             seq(
-              optional(seq("=", $._non_function_inline_type)),
+              optional(seq('=', $._non_function_inline_type)),
               optional(
                 seq(
-                  choice("=", "+="),
-                  optional("private"),
-                  field("body", $._type),
+                  choice('=', '+='),
+                  optional('private'),
+                  field('body', $._type),
                 ),
               ),
               repeat($.type_constraint),
@@ -311,16 +311,16 @@ export default grammar({
         ),
       ),
 
-    extensible_type: (_$) => "..",
+    extensible_type: (_$) => '..',
 
     type_parameters: ($) =>
       seq(
-        "<",
-        commaSep1t(seq(optional(choice("+", "-")), $.type_identifier)),
-        ">",
+        '<',
+        commaSep1t(seq(optional(choice('+', '-')), $.type_identifier)),
+        '>',
       ),
 
-    type_annotation: ($) => seq(":", $._inline_type),
+    type_annotation: ($) => seq(':', $._inline_type),
 
     _type: ($) =>
       choice($._inline_type, $.variant_type, $.record_type, $.as_aliasing_type),
@@ -345,18 +345,18 @@ export default grammar({
     polymorphic_type: ($) =>
       seq(
         choice(repeat1($.type_identifier), $.abstract_type),
-        ".",
+        '.',
         $._inline_type,
       ),
 
-    type_constraint: ($) => seq("constraint", $._type, "=", $._type),
+    type_constraint: ($) => seq('constraint', $._type, '=', $._type),
 
-    tuple_type: ($) => prec.dynamic(-1, seq("(", commaSep1t($._type), ")")),
+    tuple_type: ($) => prec.dynamic(-1, seq('(', commaSep1t($._type), ')')),
 
     variant_type: ($) =>
       prec.left(
         seq(
-          optional("|"),
+          optional('|'),
           barSep1(choice($.variant_declaration, $.variant_type_spread)),
         ),
       ),
@@ -370,17 +370,17 @@ export default grammar({
         ),
       ),
 
-    variant_type_spread: ($) => seq("...", $._type_identifier),
+    variant_type_spread: ($) => seq('...', $._type_identifier),
 
-    variant_parameters: ($) => seq("(", commaSep1t($._type), ")"),
+    variant_parameters: ($) => seq('(', commaSep1t($._type), ')'),
 
     polyvar_type: ($) =>
       prec.left(
         seq(
-          choice("[", "[>", "[<"),
-          optional("|"),
+          choice('[', '[>', '[<'),
+          optional('|'),
           barSep1($.polyvar_declaration),
-          "]",
+          ']',
         ),
       ),
 
@@ -392,21 +392,21 @@ export default grammar({
         ),
       ),
 
-    polyvar_parameters: ($) => seq("(", commaSep1t($._type), ")"),
+    polyvar_parameters: ($) => seq('(', commaSep1t($._type), ')'),
 
-    record_type: ($) => seq("{", commaSept($._record_type_member), "}"),
+    record_type: ($) => seq('{', commaSept($._record_type_member), '}'),
 
     record_type_field: ($) =>
       seq(
-        optional("mutable"),
+        optional('mutable'),
         alias($.value_identifier, $.property_identifier),
-        optional("?"),
+        optional('?'),
         $.type_annotation,
       ),
 
     type_spread: ($) =>
       seq(
-        "...",
+        '...',
         choice($.type_identifier, $.generic_type, $.type_identifier_path),
       ),
 
@@ -415,13 +415,13 @@ export default grammar({
     object_type: ($) =>
       prec.left(
         seq(
-          "{",
+          '{',
           choice(
             commaSep1t($._object_type_member),
-            seq(".", commaSept($._object_type_member)),
-            seq("..", commaSept($._object_type_member)),
+            seq('.', commaSept($._object_type_member)),
+            seq('..', commaSept($._object_type_member)),
           ),
-          "}",
+          '}',
         ),
       ),
 
@@ -429,20 +429,20 @@ export default grammar({
       choice(alias($.object_type_field, $.field), $.type_spread),
 
     object_type_field: ($) =>
-      choice(seq(alias($.string, $.property_identifier), ":", $._type)),
+      choice(seq(alias($.string, $.property_identifier), ':', $._type)),
 
     generic_type: ($) => prec.left(seq($._type_identifier, $.type_arguments)),
 
-    type_arguments: ($) => seq("<", commaSep1t($._type), ">"),
+    type_arguments: ($) => seq('<', commaSep1t($._type), '>'),
 
     function_type: ($) =>
-      prec.left(seq($.function_type_parameters, "=>", $._type)),
+      prec.left(seq($.function_type_parameters, '=>', $._type)),
 
     function_type_parameters: ($) =>
       choice($._non_function_inline_type, $._function_type_parameter_list),
 
     _function_type_parameter_list: ($) =>
-      seq("(", commaSept(alias($.function_type_parameter, $.parameter)), ")"),
+      seq('(', commaSept(alias($.function_type_parameter, $.parameter)), ')'),
 
     function_type_parameter: ($) =>
       seq(
@@ -451,17 +451,17 @@ export default grammar({
       ),
 
     let_declaration: ($) =>
-      seq(choice("export", "let"), optional("rec"), sep1("and", $.let_binding)),
+      seq(choice('export', 'let'), optional('rec'), sep1('and', $.let_binding)),
 
     let_binding: ($) =>
       seq(
-        field("pattern", $._pattern),
+        field('pattern', $._pattern),
         choice(
           seq(
             $.type_annotation,
-            optional(seq("=", field("body", $.expression))),
+            optional(seq('=', field('body', $.expression))),
           ),
-          seq("=", field("body", $.expression)),
+          seq('=', field('body', $.expression)),
         ),
       ),
 
@@ -520,33 +520,33 @@ export default grammar({
       ),
 
     parenthesized_expression: ($) =>
-      seq("(", $.expression, optional($.type_annotation), ")"),
+      seq('(', $.expression, optional($.type_annotation), ')'),
 
     value_identifier_path: ($) =>
-      seq($.module_primary_expression, ".", $.value_identifier),
+      seq($.module_primary_expression, '.', $.value_identifier),
 
     function: ($) =>
       prec.left(
         seq(
-          optional("async"),
+          optional('async'),
           choice(
-            field("parameter", $.value_identifier),
+            field('parameter', $.value_identifier),
             $._definition_signature,
           ),
-          "=>",
-          field("body", $.expression),
+          '=>',
+          field('body', $.expression),
         ),
       ),
 
     record: ($) =>
       seq(
-        "{",
+        '{',
         choice(
           $._record_single_field,
           $._record_single_pun_field,
           commaSep2t($._record_element),
         ),
-        "}",
+        '}',
       ),
 
     _record_element: ($) =>
@@ -557,14 +557,14 @@ export default grammar({
       ),
 
     record_field: ($) =>
-      seq($._record_field_name, ":", optional("?"), $.expression),
+      seq($._record_field_name, ':', optional('?'), $.expression),
 
-    _record_pun_field: ($) => seq(optional("?"), $._record_field_name),
+    _record_pun_field: ($) => seq(optional('?'), $._record_field_name),
 
-    _record_single_field: ($) => seq($.record_field, optional(",")),
+    _record_single_field: ($) => seq($.record_field, optional(',')),
 
     _record_single_pun_field: ($) =>
-      seq("?", $._record_field_name, optional(",")),
+      seq('?', $._record_field_name, optional(',')),
 
     _record_field_name: ($) =>
       choice(
@@ -574,109 +574,109 @@ export default grammar({
 
     object: ($) =>
       seq(
-        "{",
+        '{',
         choice(
           commaSep1t($._object_field),
-          seq(".", commaSept($._object_field)),
-          seq("..", commaSept($._object_field)),
+          seq('.', commaSept($._object_field)),
+          seq('..', commaSept($._object_field)),
         ),
-        "}",
+        '}',
       ),
 
     _object_field: ($) => alias($.object_field, $.field),
 
     object_field: ($) =>
-      seq(alias($.string, $.property_identifier), ":", $.expression),
+      seq(alias($.string, $.property_identifier), ':', $.expression),
 
-    tuple: ($) => seq("(", commaSep2t($.expression), ")"),
+    tuple: ($) => seq('(', commaSep2t($.expression), ')'),
 
     array: ($) =>
-      seq("[", commaSept(choice($.spread_element, $.expression)), "]"),
+      seq('[', commaSept(choice($.spread_element, $.expression)), ']'),
 
     list: ($) =>
-      seq($._list_constructor, "{", optional(commaSep1t($._list_element)), "}"),
+      seq($._list_constructor, '{', optional(commaSep1t($._list_element)), '}'),
 
     _list_element: ($) => choice($.expression, $.spread_element),
 
     dict: ($) =>
       seq(
-        alias($._dict_constructor, "dict"),
-        "{",
+        alias($._dict_constructor, 'dict'),
+        '{',
         commaSept($.dict_entry),
-        "}",
+        '}',
       ),
 
-    dict_entry: ($) => seq($.string, ":", $.expression),
+    dict_entry: ($) => seq($.string, ':', $.expression),
 
     if_expression: ($) =>
       seq(
-        "if",
+        'if',
         $.expression,
         $.block,
         repeat($.else_if_clause),
         optional($.else_clause),
       ),
 
-    else_if_clause: ($) => seq("else", "if", $.expression, $.block),
+    else_if_clause: ($) => seq('else', 'if', $.expression, $.block),
 
-    else_clause: ($) => seq("else", $.block),
+    else_clause: ($) => seq('else', $.block),
 
     switch_expression: ($) =>
       seq(
-        "switch",
+        'switch',
         $.expression,
-        "{",
+        '{',
         repeat(seq($.switch_match, optional($._semicolon))),
-        "}",
+        '}',
       ),
 
     switch_match: ($) =>
       prec.dynamic(
         -1,
         seq(
-          "|",
-          field("pattern", choice($.variant_spread_pattern, $._pattern)),
+          '|',
+          field('pattern', choice($.variant_spread_pattern, $._pattern)),
           optional($.guard),
-          "=>",
-          field("body", alias($._switch_body, $.sequence_expression)),
+          '=>',
+          field('body', alias($._switch_body, $.sequence_expression)),
         ),
       ),
 
-    guard: ($) => seq(choice("if", "when"), $.expression),
+    guard: ($) => seq(choice('if', 'when'), $.expression),
 
-    polyvar_type_pattern: ($) => seq("#", "...", $._type_identifier),
+    polyvar_type_pattern: ($) => seq('#', '...', $._type_identifier),
 
-    variant_type_pattern: ($) => seq("...", $._type_identifier),
+    variant_type_pattern: ($) => seq('...', $._type_identifier),
 
     variant_spread_pattern: ($) =>
       seq($.variant_type_pattern, optional($.as_aliasing)),
 
     try_expression: ($) =>
       seq(
-        "try",
+        'try',
         $.expression,
-        "catch",
-        "{",
+        'catch',
+        '{',
         repeat(seq($.switch_match, optional($._semicolon))),
-        "}",
+        '}',
       ),
 
     as_aliasing: ($) =>
-      prec.left(seq("as", $._pattern, optional($.type_annotation))),
+      prec.left(seq('as', $._pattern, optional($.type_annotation))),
 
-    as_aliasing_type: ($) => seq($._type, "as", $.type_identifier),
+    as_aliasing_type: ($) => seq($._type, 'as', $.type_identifier),
 
     _as_aliasing_non_function_inline_type: ($) =>
-      prec(2, seq($._non_function_inline_type, "as", $.type_identifier)),
+      prec(2, seq($._non_function_inline_type, 'as', $.type_identifier)),
 
-    assert_expression: ($) => prec.left(seq("assert", $.expression)),
+    assert_expression: ($) => prec.left(seq('assert', $.expression)),
 
     call_expression: ($) =>
       prec(
-        "call",
+        'call',
         seq(
-          field("function", $.primary_expression),
-          field("arguments", alias($.call_arguments, $.arguments)),
+          field('function', $.primary_expression),
+          field('arguments', alias($.call_arguments, $.arguments)),
         ),
       ),
 
@@ -684,24 +684,24 @@ export default grammar({
       prec.left(
         seq(
           choice($.primary_expression, $.block),
-          choice("->", "|>"),
+          choice('->', '|>'),
           choice($.primary_expression, $.block),
         ),
       ),
 
     module_pack: ($) =>
       seq(
-        "module",
+        'module',
         parenthesize(choice($._module_structure, $.type_identifier_path)),
       ),
 
     call_arguments: ($) =>
       seq(
-        "(",
+        '(',
         optional($.uncurry),
         optional(commaSep1t($._call_argument)),
         optional($.partial_application_spread),
-        ")",
+        ')',
       ),
 
     _call_argument: ($) =>
@@ -710,20 +710,20 @@ export default grammar({
         $.labeled_argument,
       ),
 
-    partial_application_spread: ($) => "...",
+    partial_application_spread: ($) => '...',
 
     labeled_argument: ($) =>
       seq(
-        "~",
-        field("label", $.value_identifier),
+        '~',
+        field('label', $.value_identifier),
         optional(
           choice(
-            "?",
+            '?',
             seq(
-              "=",
-              optional("?"),
-              field("value", $.expression),
-              optional(field("type", $.type_annotation)),
+              '=',
+              optional('?'),
+              field('value', $.expression),
+              optional(field('type', $.type_annotation)),
             ),
           ),
         ),
@@ -731,18 +731,18 @@ export default grammar({
 
     _definition_signature: ($) =>
       seq(
-        field("parameters", $.formal_parameters),
+        field('parameters', $.formal_parameters),
         optional(
           field(
-            "return_type",
+            'return_type',
             alias($._return_type_annotation, $.type_annotation),
           ),
         ),
       ),
 
-    _return_type_annotation: ($) => seq(":", $._non_function_inline_type),
+    _return_type_annotation: ($) => seq(':', $._non_function_inline_type),
 
-    formal_parameters: ($) => seq("(", optional(choice(commaSep1t($.parameter), $.uncurry)), ")"),
+    formal_parameters: ($) => seq('(', optional(choice(commaSep1t($.parameter), $.uncurry)), ')'),
 
     parameter: ($) =>
       seq(
@@ -757,7 +757,7 @@ export default grammar({
 
     labeled_parameter: ($) =>
       seq(
-        "~",
+        '~',
         $.value_identifier,
         optional($.as_aliasing),
         optional(
@@ -765,21 +765,21 @@ export default grammar({
             seq(
               $.type_annotation,
               optional(
-                field("default_value", $._labeled_parameter_default_value),
+                field('default_value', $._labeled_parameter_default_value),
               ),
             ),
             seq(
-              field("default_value", $._labeled_parameter_default_value),
+              field('default_value', $._labeled_parameter_default_value),
               optional($.type_annotation),
             ),
           ),
         ),
       ),
 
-    abstract_type: ($) => seq("type", repeat1($.type_identifier)),
+    abstract_type: ($) => seq('type', repeat1($.type_identifier)),
 
     _labeled_parameter_default_value: ($) =>
-      seq("=", choice("?", $.expression)),
+      seq('=', choice('?', $.expression)),
 
     // This negative dynamic precedence ensures that during error recovery,
     // unfinished constructs are generally treated as literal expressions,
@@ -789,7 +789,7 @@ export default grammar({
         -1,
         seq(
           choice(
-            seq(optional("?"), $.value_identifier),
+            seq(optional('?'), $.value_identifier),
             $._literal_pattern,
             $._destructuring_pattern,
             $.polyvar_type_pattern,
@@ -806,13 +806,13 @@ export default grammar({
       ),
 
     parenthesized_pattern: ($) =>
-      seq("(", $._pattern, optional($.type_annotation), ")"),
+      seq('(', $._pattern, optional($.type_annotation), ')'),
 
-    range_pattern: ($) => seq($._literal_pattern, "..", $._literal_pattern),
+    range_pattern: ($) => seq($._literal_pattern, '..', $._literal_pattern),
 
-    or_pattern: ($) => prec.left(seq($._pattern, "|", $._pattern)),
+    or_pattern: ($) => prec.left(seq($._pattern, '|', $._pattern)),
 
-    exception_pattern: ($) => seq("exception", $._pattern),
+    exception_pattern: ($) => seq('exception', $._pattern),
 
     _destructuring_pattern: ($) =>
       choice(
@@ -838,13 +838,13 @@ export default grammar({
 
     variant_pattern: ($) =>
       seq(
-        optional("?"),
+        optional('?'),
         choice($.variant_identifier, $.nested_variant_identifier),
         optional(alias($._variant_pattern_parameters, $.formal_parameters)),
       ),
 
     _variant_pattern_parameters: ($) =>
-      seq("(", commaSept($._variant_pattern_parameter), ")"),
+      seq('(', commaSept($._variant_pattern_parameter), ')'),
 
     _variant_pattern_parameter: ($) =>
       seq($._pattern, optional($.type_annotation)),
@@ -857,66 +857,66 @@ export default grammar({
 
     record_pattern: ($) =>
       seq(
-        "{",
+        '{',
         commaSep1t(
           seq(
-            optional("?"),
+            optional('?'),
             choice($.value_identifier, $.value_identifier_path),
-            optional(seq(":", $._pattern)),
+            optional(seq(':', $._pattern)),
           ),
         ),
-        "}",
+        '}',
       ),
 
     tuple_item_pattern: ($) => seq($._pattern, optional($.type_annotation)),
 
-    tuple_pattern: ($) => seq("(", commaSep2t($.tuple_item_pattern), ")"),
+    tuple_pattern: ($) => seq('(', commaSep2t($.tuple_item_pattern), ')'),
 
     array_pattern: ($) =>
-      seq("[", optional(commaSep1t($._collection_element_pattern)), "]"),
+      seq('[', optional(commaSep1t($._collection_element_pattern)), ']'),
 
     list_pattern: ($) =>
       seq(
         $._list_constructor,
-        "{",
+        '{',
         optional(commaSep1t($._collection_element_pattern)),
-        "}",
+        '}',
       ),
 
     dict_pattern: ($) =>
       seq(
-        alias($._dict_constructor, "dict"),
-        "{",
+        alias($._dict_constructor, 'dict'),
+        '{',
         commaSept($.dict_pattern_entry),
-        "}",
+        '}',
       ),
 
-    dict_pattern_entry: ($) => seq($.string, ":", $._pattern),
+    dict_pattern_entry: ($) => seq($.string, ':', $._pattern),
 
     _collection_element_pattern: ($) =>
       seq(choice($._pattern, $.spread_pattern), optional($.as_aliasing)),
 
     spread_pattern: ($) =>
-      seq("...", choice($.value_identifier, $.list_pattern, $.array_pattern)),
+      seq('...', choice($.value_identifier, $.list_pattern, $.array_pattern)),
 
-    lazy_pattern: ($) => seq("lazy", $._pattern),
+    lazy_pattern: ($) => seq('lazy', $._pattern),
 
     _jsx_element: ($) => choice($.jsx_element, $.jsx_self_closing_element),
 
     jsx_element: ($) =>
       seq(
-        field("open_tag", $.jsx_opening_element),
+        field('open_tag', $.jsx_opening_element),
         repeat($._jsx_child),
-        field("close_tag", $.jsx_closing_element),
+        field('close_tag', $.jsx_closing_element),
       ),
 
-    jsx_fragment: ($) => seq("<", ">", repeat($._jsx_child), "<", "/", ">"),
+    jsx_fragment: ($) => seq('<', '>', repeat($._jsx_child), '<', '/', '>'),
 
     jsx_expression: ($) =>
       seq(
-        "{",
+        '{',
         optional(choice($._one_or_more_statements, $.spread_element)),
-        "}",
+        '}',
       ),
 
     _jsx_child: ($) =>
@@ -938,10 +938,10 @@ export default grammar({
       prec.dynamic(
         -1,
         seq(
-          "<",
-          field("name", $._jsx_element_name),
-          repeat(field("attribute", $._jsx_attribute)),
-          ">",
+          '<',
+          field('name', $._jsx_element_name),
+          repeat(field('attribute', $._jsx_attribute)),
+          '>',
         ),
       ),
 
@@ -950,10 +950,10 @@ export default grammar({
 
     nested_jsx_identifier: ($) =>
       prec(
-        "member",
+        'member',
         seq(
           choice($._jsx_identifier, $.nested_jsx_identifier),
-          ".",
+          '.',
           $._jsx_identifier,
         ),
       ),
@@ -962,15 +962,15 @@ export default grammar({
       choice($._jsx_identifier, $.nested_jsx_identifier),
 
     jsx_closing_element: ($) =>
-      seq("<", "/", field("name", $._jsx_element_name), ">"),
+      seq('<', '/', field('name', $._jsx_element_name), '>'),
 
     jsx_self_closing_element: ($) =>
       seq(
-        "<",
-        field("name", $._jsx_element_name),
-        repeat(field("attribute", $._jsx_attribute)),
-        "/",
-        ">",
+        '<',
+        field('name', $._jsx_element_name),
+        repeat(field('attribute', $._jsx_attribute)),
+        '/',
+        '>',
       ),
 
     _jsx_attribute_name: ($) =>
@@ -980,20 +980,20 @@ export default grammar({
 
     jsx_attribute: ($) =>
       seq(
-        optional("?"),
+        optional('?'),
         $._jsx_attribute_name,
-        optional(seq("=", optional("?"), $._jsx_attribute_value)),
+        optional(seq('=', optional('?'), $._jsx_attribute_value)),
       ),
 
     _jsx_attribute_value: ($) => choice($.primary_expression, $.jsx_expression),
 
     mutation_expression: ($) =>
-      seq($._mutation_lvalue, choice("=", ":="), $.expression),
+      seq($._mutation_lvalue, choice('=', ':='), $.expression),
 
     _mutation_lvalue: ($) =>
       choice($.value_identifier, $.member_expression, $.subscript_expression),
 
-    await_expression: ($) => seq("await", $.expression),
+    await_expression: ($) => seq('await', $.expression),
 
     decorator: ($) =>
       choice(
@@ -1002,103 +1002,103 @@ export default grammar({
       ),
 
     decorator_arguments: ($) =>
-      seq("(", choice(commaSept($.expression), $.type_annotation), ")"),
+      seq('(', choice(commaSept($.expression), $.type_annotation), ')'),
 
     subscript_expression: ($) =>
       prec.right(
-        "member",
+        'member',
         seq(
-          field("object", $.primary_expression),
-          "[",
-          field("index", $.expression),
-          "]",
+          field('object', $.primary_expression),
+          '[',
+          field('index', $.expression),
+          ']',
         ),
       ),
 
     member_expression: ($) =>
       prec(
-        "member",
+        'member',
         seq(
-          field("record", $.primary_expression),
-          ".",
+          field('record', $.primary_expression),
+          '.',
           optional(
             seq(
               field(
-                "module",
-                seq(repeat(seq($.module_identifier, ".")), $.module_identifier),
+                'module',
+                seq(repeat(seq($.module_identifier, '.')), $.module_identifier),
               ),
-              ".",
+              '.',
             ),
           ),
-          field("property", alias($.value_identifier, $.property_identifier)),
+          field('property', alias($.value_identifier, $.property_identifier)),
         ),
       ),
 
-    spread_element: ($) => seq("...", $.expression),
+    spread_element: ($) => seq('...', $.expression),
 
     ternary_expression: ($) =>
       prec.left(
         seq(
-          field("condition", $.expression),
-          "?",
-          field("consequence", $.expression),
-          ":",
-          field("alternative", $.expression),
+          field('condition', $.expression),
+          '?',
+          field('consequence', $.expression),
+          ':',
+          field('alternative', $.expression),
         ),
       ),
 
     for_expression: ($) =>
       seq(
-        "for",
+        'for',
         $.value_identifier,
-        "in",
+        'in',
         $.expression,
-        choice("to", "downto"),
+        choice('to', 'downto'),
         $.expression,
         $.block,
       ),
 
-    while_expression: ($) => seq("while", $.expression, $.block),
+    while_expression: ($) => seq('while', $.expression, $.block),
 
-    lazy_expression: ($) => seq("lazy", $.expression),
+    lazy_expression: ($) => seq('lazy', $.expression),
 
     binary_expression: ($) =>
       choice(
         ...[
-          ["&&&", "binary_bitand"],
-          ["&&", "binary_and"],
-          ["|||", "binary_bitor"],
-          ["||", "binary_or"],
-          ["^^^", "binary_bitxor"],
-          ["++", "binary_plus"],
-          ["+", "binary_plus"],
-          ["+.", "binary_plus"],
-          ["-", "binary_plus"],
-          ["-.", "binary_plus"],
-          ["*", "binary_times"],
-          ["*.", "binary_times"],
-          ["%", "binary_times"],
-          ["**", "binary_pow", "right"],
-          ["/", "binary_times"],
-          ["/.", "binary_times"],
-          ["<<", "binary_shift"],
-          [">>>", "binary_shift"],
-          [">>", "binary_shift"],
-          ["<", "binary_relation"],
-          ["<=", "binary_relation"],
-          ["==", "binary_relation"],
-          ["===", "binary_relation"],
-          ["!=", "binary_relation"],
-          ["!==", "binary_relation"],
-          [">=", "binary_relation"],
-          [">", "binary_relation"],
+          ['&&&', 'binary_bitand'],
+          ['&&', 'binary_and'],
+          ['|||', 'binary_bitor'],
+          ['||', 'binary_or'],
+          ['^^^', 'binary_bitxor'],
+          ['++', 'binary_plus'],
+          ['+', 'binary_plus'],
+          ['+.', 'binary_plus'],
+          ['-', 'binary_plus'],
+          ['-.', 'binary_plus'],
+          ['*', 'binary_times'],
+          ['*.', 'binary_times'],
+          ['%', 'binary_times'],
+          ['**', 'binary_pow', 'right'],
+          ['/', 'binary_times'],
+          ['/.', 'binary_times'],
+          ['<<', 'binary_shift'],
+          ['>>>', 'binary_shift'],
+          ['>>', 'binary_shift'],
+          ['<', 'binary_relation'],
+          ['<=', 'binary_relation'],
+          ['==', 'binary_relation'],
+          ['===', 'binary_relation'],
+          ['!=', 'binary_relation'],
+          ['!==', 'binary_relation'],
+          ['>=', 'binary_relation'],
+          ['>', 'binary_relation'],
         ].map(([operator, precedence, associativity]) =>
-          (associativity === "right" ? prec.right : prec.left)(
+          (associativity === 'right' ? prec.right : prec.left)(
             precedence,
             seq(
-              field("left", $.expression),
-              field("operator", operator),
-              field("right", $.expression),
+              field('left', $.expression),
+              field('operator', operator),
+              field('right', $.expression),
             ),
           ),
         ),
@@ -1106,20 +1106,20 @@ export default grammar({
 
     coercion_expression: ($) =>
       prec.left(
-        "coercion_relation",
+        'coercion_relation',
         choice(
           seq(
-            field("left", $.expression),
-            field("operator", ":>"),
-            field("right", $._type),
+            field('left', $.expression),
+            field('operator', ':>'),
+            field('right', $._type),
           ),
           seq(
-            "(",
-            field("left", $.expression),
-            field("source_type", $.type_annotation),
-            field("operator", ":>"),
-            field("right", $._type),
-            ")",
+            '(',
+            field('left', $.expression),
+            field('source_type', $.type_annotation),
+            field('operator', ':>'),
+            field('right', $._type),
+            ')',
           ),
         ),
       ),
@@ -1127,16 +1127,16 @@ export default grammar({
     unary_expression: ($) =>
       choice(
         ...[
-          ["~~~", "unary_not"],
-          ["!", "unary_not"],
-          ["-", "unary_not"],
-          ["-.", "unary_not"],
-          ["+", "unary_not"],
-          ["+.", "unary_not"],
+          ['~~~', 'unary_not'],
+          ['!', 'unary_not'],
+          ['-', 'unary_not'],
+          ['-.', 'unary_not'],
+          ['+', 'unary_not'],
+          ['+.', 'unary_not'],
         ].map(([operator, precedence]) =>
           prec.left(
             precedence,
-            seq(field("operator", operator), field("argument", $.expression)),
+            seq(field('operator', operator), field('argument', $.expression)),
           ),
         ),
       ),
@@ -1144,14 +1144,14 @@ export default grammar({
     extension_expression: ($) =>
       prec.right(
         seq(
-          repeat1("%"),
+          repeat1('%'),
           $.extension_identifier,
           optional($._extension_expression_payload),
         ),
       ),
 
     _extension_expression_payload: ($) =>
-      seq("(", choice($._one_or_more_statements, $.type_annotation), ")"),
+      seq('(', choice($._one_or_more_statements, $.type_annotation), ')'),
 
     variant: ($) =>
       prec.right(
@@ -1162,10 +1162,10 @@ export default grammar({
       ),
 
     nested_variant_identifier: ($) =>
-      seq($.module_primary_expression, ".", $.variant_identifier),
+      seq($.module_primary_expression, '.', $.variant_identifier),
 
     variant_arguments: ($) =>
-      seq("(", commaSept(seq($.expression, optional($.type_annotation))), ")"),
+      seq('(', commaSept(seq($.expression, optional($.type_annotation))), ')'),
 
     polyvar: ($) =>
       prec.right(
@@ -1178,7 +1178,7 @@ export default grammar({
     _type_identifier: ($) => choice($.type_identifier, $.type_identifier_path),
 
     type_identifier_path: ($) =>
-      seq($.module_primary_expression, ".", $.type_identifier),
+      seq($.module_primary_expression, '.', $.type_identifier),
 
     module_expression: ($) =>
       choice(
@@ -1197,22 +1197,22 @@ export default grammar({
       ),
 
     parenthesized_module_expression: ($) =>
-      seq("(", $.module_expression, optional($.module_type_annotation), ")"),
+      seq('(', $.module_expression, optional($.module_type_annotation), ')'),
 
     module_identifier_path: ($) =>
       path($.module_primary_expression, $.module_identifier),
 
     module_type_of: ($) =>
       prec.left(
-        seq("module", "type", "of", choice($.module_expression, $.block)),
+        seq('module', 'type', 'of', choice($.module_expression, $.block)),
       ),
 
     _module_type_constraint_with: ($) =>
       prec.right(
         seq(
-          "with",
+          'with',
           sep1(
-            choice("and", "with"),
+            choice('and', 'with'),
             choice($.constrain_module, $.constrain_type),
           ),
         ),
@@ -1223,10 +1223,10 @@ export default grammar({
         choice(
           seq($.module_expression, $._module_type_constraint_with),
           seq(
-            "(",
+            '(',
             $.module_expression,
             $._module_type_constraint_with,
-            ")",
+            ')',
             $._module_type_constraint_with,
           ),
         ),
@@ -1234,19 +1234,19 @@ export default grammar({
 
     constrain_module: ($) =>
       seq(
-        "module",
+        'module',
         $.module_primary_expression,
-        choice("=", ":="),
+        choice('=', ':='),
         $.module_primary_expression,
       ),
 
-    constrain_type: ($) => seq("type", $._type, choice("=", ":="), optional("private"), $._type),
+    constrain_type: ($) => seq('type', $._type, choice('=', ':='), optional('private'), $._type),
 
     functor_use: ($) =>
       seq($.module_primary_expression, alias($.functor_arguments, $.arguments)),
 
     functor_arguments: ($) =>
-      seq("(", optional(commaSep1t($._functor_argument)), ")"),
+      seq('(', optional(commaSep1t($._functor_argument)), ')'),
 
     _functor_argument: ($) => choice($.module_expression, $.block),
 
@@ -1254,10 +1254,10 @@ export default grammar({
 
     polyvar_identifier: ($) =>
       seq(
-        "#",
+        '#',
         choice(
           /[a-zA-Z0-9_']+/,
-          seq(optional("\\"), alias($.string, $.polyvar_string)),
+          seq(optional('\\'), alias($.string, $.polyvar_string)),
         ),
       ),
 
@@ -1277,10 +1277,10 @@ export default grammar({
 
     regex: ($) =>
       seq(
-        "/",
-        field("pattern", $.regex_pattern),
-        token.immediate(prec(1, "/")),
-        optional(field("flags", $.regex_flags)),
+        '/',
+        field('pattern', $.regex_pattern),
+        token.immediate(prec(1, '/')),
+        optional(field('flags', $.regex_flags)),
       ),
 
     regex_pattern: (_) =>
@@ -1289,8 +1289,8 @@ export default grammar({
           -1,
           repeat1(
             choice(
-              seq("[", repeat(choice(seq("\\", /./), /[^\]\n\\]/)), "]"),
-              seq("\\", /./),
+              seq('[', repeat(choice(seq('\\', /./), /[^\]\n\\]/)), ']'),
+              seq('\\', /./),
               /[^/\\\[\n]/,
             ),
           ),
@@ -1302,53 +1302,53 @@ export default grammar({
     number: ($) => {
       // OCaml: https://github.com/tree-sitter/tree-sitter-ocaml/blob/f1106bf834703f1f2f795da1a3b5f8f40174ffcc/ocaml/grammar.js#L26
       const hex_literal = seq(
-        optional(choice("-", "+")),
+        optional(choice('-', '+')),
         /0[xX][0-9A-Fa-f][0-9A-Fa-f_]*(\.[0-9A-Fa-f_]*)?([pP][+\-]?[0-9][0-9_]*)?[g-zG-Z]?/,
       );
 
       const decimal_digits = /\d(_?\d)*/;
-      const signed_integer = seq(optional(choice("-", "+")), decimal_digits);
-      const exponent_part = seq(choice("e", "E"), signed_integer);
+      const signed_integer = seq(optional(choice('-', '+')), decimal_digits);
+      const exponent_part = seq(choice('e', 'E'), signed_integer);
 
-      const binary_literal = seq(choice("0b", "0B"), /[0-1](_?[0-1])*/);
+      const binary_literal = seq(choice('0b', '0B'), /[0-1](_?[0-1])*/);
 
-      const octal_literal = seq(choice("0o", "0O"), /[0-7](_?[0-7])*/);
+      const octal_literal = seq(choice('0o', '0O'), /[0-7](_?[0-7])*/);
 
       const bigint_literal = seq(
-        optional(choice("-", "+")),
+        optional(choice('-', '+')),
         choice(hex_literal, binary_literal, octal_literal, decimal_digits),
-        "n",
+        'n',
       );
 
       const decimal_integer_literal = choice(
-        repeat1("0"),
-        seq(repeat("0"), /[1-9]/, optional(seq(optional("_"), decimal_digits))),
+        repeat1('0'),
+        seq(repeat('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits))),
       );
 
       const decimal_literal = seq(
-        optional(choice("-", "+")),
+        optional(choice('-', '+')),
         choice(
           seq(
             decimal_integer_literal,
-            ".",
+            '.',
             optional(decimal_digits),
             optional(exponent_part),
           ),
-          seq(".", decimal_digits, optional(exponent_part)),
+          seq('.', decimal_digits, optional(exponent_part)),
           seq(decimal_integer_literal, exponent_part),
           decimal_digits,
         ),
       );
 
       const int_32_64 = seq(
-        optional(choice("-", "+")),
+        optional(choice('-', '+')),
         choice(
           decimal_integer_literal,
           binary_literal,
           octal_literal,
           hex_literal,
         ),
-        choice("L", "l"),
+        choice('L', 'l'),
       );
 
       return token(
@@ -1363,11 +1363,11 @@ export default grammar({
       );
     },
 
-    unit: ($) => seq("(", ")"),
-    unit_type: ($) => "unit",
+    unit: ($) => seq('(', ')'),
+    unit_type: ($) => 'unit',
 
-    true: ($) => "true",
-    false: ($) => "false",
+    true: ($) => 'true',
+    false: ($) => 'false',
 
     string: ($) =>
       seq(
@@ -1391,7 +1391,7 @@ export default grammar({
     escape_sequence: ($) =>
       token.immediate(
         seq(
-          "\\",
+          '\\',
           choice(
             /[^xu0-7]/,
             /[0-7]{1,3}/,
@@ -1413,11 +1413,11 @@ export default grammar({
                 seq('\\"', /[^"]+/, '"'),
               ),
             ),
-            "`",
+            '`',
           ),
         ),
         optional($.template_string_content),
-        "`",
+        '`',
       ),
 
     template_string_content: ($) =>
@@ -1426,59 +1426,115 @@ export default grammar({
           $._template_chars,
           $.template_substitution,
           /\s/,
-          choice(alias("\\`", $.escape_sequence), $.escape_sequence),
+          choice(alias('\\`', $.escape_sequence), $.escape_sequence),
         ),
       ),
 
     template_substitution: ($) =>
-      choice(seq("$", $.value_identifier), seq("${", $.expression, "}")),
+      choice(seq('$', $.value_identifier), seq('${', $.expression, '}')),
 
     character: ($) =>
-      seq("'", repeat(choice(/[^\\']/, $.escape_sequence)), "'"),
+      seq('\'', repeat(choice(/[^\\']/, $.escape_sequence)), '\''),
 
     _unescaped_template_string_fragment: ($) =>
       token.immediate(prec(1, /[^`\\\$]+/)),
 
-    lparen: ($) => alias($._lparen, "("),
-    rparen: ($) => alias($._rparen, ")"),
-    uncurry: ($) => ".",
+    lparen: ($) => alias($._lparen, '('),
+    rparen: ($) => alias($._rparen, ')'),
+    uncurry: ($) => '.',
 
-    _reserved_identifier: ($) => choice("async", "unpack"),
+    _reserved_identifier: ($) => choice('async', 'unpack'),
   },
 });
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function barSep1(rule) {
-  return seq(rule, repeat(seq("|", rule)));
+  return seq(rule, repeat(seq('|', rule)));
 }
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function commaSep1(rule) {
-  return seq(rule, repeat(seq(",", rule)));
+  return seq(rule, repeat(seq(',', rule)));
 }
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function commaSep2(rule) {
-  return seq(rule, ",", commaSep1(rule));
+  return seq(rule, ',', commaSep1(rule));
 }
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function commaSep1t(rule) {
-  return seq(commaSep1(rule), optional(","));
+  return seq(commaSep1(rule), optional(','));
 }
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function commaSep2t(rule) {
-  return seq(commaSep2(rule), optional(","));
+  return seq(commaSep2(rule), optional(','));
 }
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {ChoiceRule}
+ */
 function commaSept(rule) {
   return optional(commaSep1t(rule));
 }
 
+/**
+ *
+ * @param {string} delimiter
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function sep1(delimiter, rule) {
   return seq(rule, repeat(seq(delimiter, rule)));
 }
 
+/**
+ *
+ * @param {Rule} prefix
+ * @param {Rule} final
+ *
+ * @returns {ChoiceRule}
+ */
 function path(prefix, final) {
-  return choice(final, seq(prefix, ".", final));
+  return choice(final, seq(prefix, '.', final));
 }
 
+/**
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
 function parenthesize(rule) {
-  return seq("(", rule, ")");
+  return seq('(', rule, ')');
 }

--- a/grammar.js
+++ b/grammar.js
@@ -171,7 +171,7 @@ export default grammar({
         $.expression_statement,
         $.declaration,
         $.open_statement,
-        $.include_statement,
+        $.include_statement
       ),
 
     block: ($) =>
@@ -182,7 +182,7 @@ export default grammar({
     include_statement: ($) =>
       seq(
         'include',
-        choice($._module_definition, parenthesize($._module_structure)),
+        choice($._module_definition, parenthesize($._module_structure))
       ),
 
     declaration: ($) =>
@@ -191,7 +191,7 @@ export default grammar({
         $.let_declaration,
         $.module_declaration,
         $.external_declaration,
-        $.exception_declaration,
+        $.exception_declaration
       ),
 
     module_binding: ($) =>
@@ -203,18 +203,18 @@ export default grammar({
               ':',
               field(
                 'signature',
-                choice($.block, $.module_expression, $.functor),
-              ),
-            ),
+                choice($.block, $.module_expression, $.functor)
+              )
+            )
           ),
           optional(
             seq(
               '=',
               optional('await'),
-              field('definition', $._module_definition),
-            ),
-          ),
-        ),
+              field('definition', $._module_definition)
+            )
+          )
+        )
       ),
 
     module_declaration: ($) =>
@@ -222,7 +222,7 @@ export default grammar({
         'module',
         optional('rec'),
         optional('type'),
-        sep1('and', $.module_binding),
+        sep1('and', $.module_binding)
       ),
 
     _module_structure: ($) =>
@@ -240,15 +240,15 @@ export default grammar({
             choice(
               $.value_identifier,
               $.value_identifier_path,
-              $.member_expression,
+              $.member_expression
             ),
-            optional($.module_type_annotation),
+            optional($.module_type_annotation)
           ),
           seq($.call_expression, optional($.module_type_annotation)),
           seq($.module_pack, optional($.module_type_annotation)),
-          $.extension_expression,
+          $.extension_expression
         ),
-        ')',
+        ')'
       ),
 
     functor: ($) =>
@@ -256,7 +256,7 @@ export default grammar({
         field('parameters', $.functor_parameters),
         optional(field('return_module_type', $.module_type_annotation)),
         '=>',
-        field('body', $._module_definition),
+        field('body', $._module_definition)
       ),
 
     functor_parameters: ($) =>
@@ -277,8 +277,8 @@ export default grammar({
         $.variant_identifier,
         optional($.variant_parameters),
         optional(
-          seq('=', choice($.variant_identifier, $.nested_variant_identifier)),
-        ),
+          seq('=', choice($.variant_identifier, $.nested_variant_identifier))
+        )
       ),
 
     type_declaration: ($) =>
@@ -286,7 +286,7 @@ export default grammar({
         optional('export'),
         'type',
         optional('rec'),
-        sep1('and', $.type_binding),
+        sep1('and', $.type_binding)
       ),
 
     type_binding: ($) =>
@@ -302,13 +302,13 @@ export default grammar({
                 seq(
                   choice('=', '+='),
                   optional('private'),
-                  field('body', $._type),
-                ),
+                  field('body', $._type)
+                )
               ),
-              repeat($.type_constraint),
-            ),
-          ),
-        ),
+              repeat($.type_constraint)
+            )
+          )
+        )
       ),
 
     extensible_type: (_$) => '..',
@@ -317,7 +317,7 @@ export default grammar({
       seq(
         '<',
         commaSep1t(seq(optional(choice('+', '-')), $.type_identifier)),
-        '>',
+        '>'
       ),
 
     type_annotation: ($) => seq(':', $._inline_type),
@@ -339,14 +339,14 @@ export default grammar({
         $.module_pack,
         $.unit,
         $.polymorphic_type,
-        alias($._as_aliasing_non_function_inline_type, $.as_aliasing_type),
+        alias($._as_aliasing_non_function_inline_type, $.as_aliasing_type)
       ),
 
     polymorphic_type: ($) =>
       seq(
         choice(repeat1($.type_identifier), $.abstract_type),
         '.',
-        $._inline_type,
+        $._inline_type
       ),
 
     type_constraint: ($) => seq('constraint', $._type, '=', $._type),
@@ -357,8 +357,8 @@ export default grammar({
       prec.left(
         seq(
           optional('|'),
-          barSep1(choice($.variant_declaration, $.variant_type_spread)),
-        ),
+          barSep1(choice($.variant_declaration, $.variant_type_spread))
+        )
       ),
 
     variant_declaration: ($) =>
@@ -366,8 +366,8 @@ export default grammar({
         seq(
           $.variant_identifier,
           optional($.variant_parameters),
-          optional($.type_annotation),
-        ),
+          optional($.type_annotation)
+        )
       ),
 
     variant_type_spread: ($) => seq('...', $._type_identifier),
@@ -380,16 +380,16 @@ export default grammar({
           choice('[', '[>', '[<'),
           optional('|'),
           barSep1($.polyvar_declaration),
-          ']',
-        ),
+          ']'
+        )
       ),
 
     polyvar_declaration: ($) =>
       prec.right(
         choice(
           seq($.polyvar_identifier, optional($.polyvar_parameters)),
-          $._inline_type,
-        ),
+          $._inline_type
+        )
       ),
 
     polyvar_parameters: ($) => seq('(', commaSep1t($._type), ')'),
@@ -401,13 +401,13 @@ export default grammar({
         optional('mutable'),
         alias($.value_identifier, $.property_identifier),
         optional('?'),
-        $.type_annotation,
+        $.type_annotation
       ),
 
     type_spread: ($) =>
       seq(
         '...',
-        choice($.type_identifier, $.generic_type, $.type_identifier_path),
+        choice($.type_identifier, $.generic_type, $.type_identifier_path)
       ),
 
     _record_type_member: ($) => choice($.record_type_field, $.type_spread),
@@ -419,10 +419,10 @@ export default grammar({
           choice(
             commaSep1t($._object_type_member),
             seq('.', commaSept($._object_type_member)),
-            seq('..', commaSept($._object_type_member)),
+            seq('..', commaSept($._object_type_member))
           ),
-          '}',
-        ),
+          '}'
+        )
       ),
 
     _object_type_member: ($) =>
@@ -447,7 +447,7 @@ export default grammar({
     function_type_parameter: ($) =>
       seq(
         optional($.uncurry),
-        choice($._type, seq($.uncurry, $._type), $.labeled_parameter),
+        choice($._type, seq($.uncurry, $._type), $.labeled_parameter)
       ),
 
     let_declaration: ($) =>
@@ -459,10 +459,10 @@ export default grammar({
         choice(
           seq(
             $.type_annotation,
-            optional(seq('=', field('body', $.expression))),
+            optional(seq('=', field('body', $.expression)))
           ),
-          seq('=', field('body', $.expression)),
-        ),
+          seq('=', field('body', $.expression))
+        )
       ),
 
     expression_statement: ($) => $.expression,
@@ -481,7 +481,7 @@ export default grammar({
         $.mutation_expression,
         $.await_expression,
         $.block,
-        $.assert_expression,
+        $.assert_expression
       ),
 
     primary_expression: ($) =>
@@ -516,7 +516,7 @@ export default grammar({
         $.extension_expression,
         $.lazy_expression,
         $._jsx_element,
-        $.regex,
+        $.regex
       ),
 
     parenthesized_expression: ($) =>
@@ -531,11 +531,11 @@ export default grammar({
           optional('async'),
           choice(
             field('parameter', $.value_identifier),
-            $._definition_signature,
+            $._definition_signature
           ),
           '=>',
-          field('body', $.expression),
-        ),
+          field('body', $.expression)
+        )
       ),
 
     record: ($) =>
@@ -544,16 +544,16 @@ export default grammar({
         choice(
           $._record_single_field,
           $._record_single_pun_field,
-          commaSep2t($._record_element),
+          commaSep2t($._record_element)
         ),
-        '}',
+        '}'
       ),
 
     _record_element: ($) =>
       choice(
         $.spread_element,
         $.record_field,
-        alias($._record_pun_field, $.record_field),
+        alias($._record_pun_field, $.record_field)
       ),
 
     record_field: ($) =>
@@ -569,7 +569,7 @@ export default grammar({
     _record_field_name: ($) =>
       choice(
         alias($.value_identifier, $.property_identifier),
-        alias($.value_identifier_path, $.property_identifier),
+        alias($.value_identifier_path, $.property_identifier)
       ),
 
     object: ($) =>
@@ -578,9 +578,9 @@ export default grammar({
         choice(
           commaSep1t($._object_field),
           seq('.', commaSept($._object_field)),
-          seq('..', commaSept($._object_field)),
+          seq('..', commaSept($._object_field))
         ),
-        '}',
+        '}'
       ),
 
     _object_field: ($) => alias($.object_field, $.field),
@@ -603,7 +603,7 @@ export default grammar({
         alias($._dict_constructor, 'dict'),
         '{',
         commaSept($.dict_entry),
-        '}',
+        '}'
       ),
 
     dict_entry: ($) => seq($.string, ':', $.expression),
@@ -614,7 +614,7 @@ export default grammar({
         $.expression,
         $.block,
         repeat($.else_if_clause),
-        optional($.else_clause),
+        optional($.else_clause)
       ),
 
     else_if_clause: ($) => seq('else', 'if', $.expression, $.block),
@@ -627,7 +627,7 @@ export default grammar({
         $.expression,
         '{',
         repeat(seq($.switch_match, optional($._semicolon))),
-        '}',
+        '}'
       ),
 
     switch_match: ($) =>
@@ -638,8 +638,8 @@ export default grammar({
           field('pattern', choice($.variant_spread_pattern, $._pattern)),
           optional($.guard),
           '=>',
-          field('body', alias($._switch_body, $.sequence_expression)),
-        ),
+          field('body', alias($._switch_body, $.sequence_expression))
+        )
       ),
 
     guard: ($) => seq(choice('if', 'when'), $.expression),
@@ -658,7 +658,7 @@ export default grammar({
         'catch',
         '{',
         repeat(seq($.switch_match, optional($._semicolon))),
-        '}',
+        '}'
       ),
 
     as_aliasing: ($) =>
@@ -676,8 +676,8 @@ export default grammar({
         'call',
         seq(
           field('function', $.primary_expression),
-          field('arguments', alias($.call_arguments, $.arguments)),
-        ),
+          field('arguments', alias($.call_arguments, $.arguments))
+        )
       ),
 
     pipe_expression: ($) =>
@@ -685,14 +685,14 @@ export default grammar({
         seq(
           choice($.primary_expression, $.block),
           choice('->', '|>'),
-          choice($.primary_expression, $.block),
-        ),
+          choice($.primary_expression, $.block)
+        )
       ),
 
     module_pack: ($) =>
       seq(
         'module',
-        parenthesize(choice($._module_structure, $.type_identifier_path)),
+        parenthesize(choice($._module_structure, $.type_identifier_path))
       ),
 
     call_arguments: ($) =>
@@ -701,13 +701,13 @@ export default grammar({
         optional($.uncurry),
         optional(commaSep1t($._call_argument)),
         optional($.partial_application_spread),
-        ')',
+        ')'
       ),
 
     _call_argument: ($) =>
       choice(
         seq($.expression, optional($.type_annotation)),
-        $.labeled_argument,
+        $.labeled_argument
       ),
 
     partial_application_spread: ($) => '...',
@@ -723,10 +723,10 @@ export default grammar({
               '=',
               optional('?'),
               field('value', $.expression),
-              optional(field('type', $.type_annotation)),
-            ),
-          ),
-        ),
+              optional(field('type', $.type_annotation))
+            )
+          )
+        )
       ),
 
     _definition_signature: ($) =>
@@ -735,14 +735,15 @@ export default grammar({
         optional(
           field(
             'return_type',
-            alias($._return_type_annotation, $.type_annotation),
-          ),
-        ),
+            alias($._return_type_annotation, $.type_annotation)
+          )
+        )
       ),
 
     _return_type_annotation: ($) => seq(':', $._non_function_inline_type),
 
-    formal_parameters: ($) => seq('(', optional(choice(commaSep1t($.parameter), $.uncurry)), ')'),
+    formal_parameters: ($) =>
+      seq('(', optional(choice(commaSep1t($.parameter), $.uncurry)), ')'),
 
     parameter: ($) =>
       seq(
@@ -751,8 +752,8 @@ export default grammar({
           seq($._pattern, optional($.type_annotation)),
           $.labeled_parameter,
           $.unit,
-          $.abstract_type,
-        ),
+          $.abstract_type
+        )
       ),
 
     labeled_parameter: ($) =>
@@ -765,15 +766,15 @@ export default grammar({
             seq(
               $.type_annotation,
               optional(
-                field('default_value', $._labeled_parameter_default_value),
-              ),
+                field('default_value', $._labeled_parameter_default_value)
+              )
             ),
             seq(
               field('default_value', $._labeled_parameter_default_value),
-              optional($.type_annotation),
-            ),
-          ),
-        ),
+              optional($.type_annotation)
+            )
+          )
+        )
       ),
 
     abstract_type: ($) => seq('type', repeat1($.type_identifier)),
@@ -799,10 +800,10 @@ export default grammar({
             $.parenthesized_pattern,
             $.or_pattern,
             $.range_pattern,
-            $.exception_pattern,
+            $.exception_pattern
           ),
-          optional($.as_aliasing),
-        ),
+          optional($.as_aliasing)
+        )
       ),
 
     parenthesized_pattern: ($) =>
@@ -822,7 +823,7 @@ export default grammar({
         $.tuple_pattern,
         $.array_pattern,
         $.list_pattern,
-        $.dict_pattern,
+        $.dict_pattern
       ),
 
     _literal_pattern: ($) =>
@@ -833,14 +834,14 @@ export default grammar({
         $.number,
         $.true,
         $.false,
-        $.regex,
+        $.regex
       ),
 
     variant_pattern: ($) =>
       seq(
         optional('?'),
         choice($.variant_identifier, $.nested_variant_identifier),
-        optional(alias($._variant_pattern_parameters, $.formal_parameters)),
+        optional(alias($._variant_pattern_parameters, $.formal_parameters))
       ),
 
     _variant_pattern_parameters: ($) =>
@@ -852,7 +853,7 @@ export default grammar({
     polyvar_pattern: ($) =>
       seq(
         $.polyvar_identifier,
-        optional(alias($._variant_pattern_parameters, $.formal_parameters)),
+        optional(alias($._variant_pattern_parameters, $.formal_parameters))
       ),
 
     record_pattern: ($) =>
@@ -862,10 +863,10 @@ export default grammar({
           seq(
             optional('?'),
             choice($.value_identifier, $.value_identifier_path),
-            optional(seq(':', $._pattern)),
-          ),
+            optional(seq(':', $._pattern))
+          )
         ),
-        '}',
+        '}'
       ),
 
     tuple_item_pattern: ($) => seq($._pattern, optional($.type_annotation)),
@@ -880,7 +881,7 @@ export default grammar({
         $._list_constructor,
         '{',
         optional(commaSep1t($._collection_element_pattern)),
-        '}',
+        '}'
       ),
 
     dict_pattern: ($) =>
@@ -888,7 +889,7 @@ export default grammar({
         alias($._dict_constructor, 'dict'),
         '{',
         commaSept($.dict_pattern_entry),
-        '}',
+        '}'
       ),
 
     dict_pattern_entry: ($) => seq($.string, ':', $._pattern),
@@ -907,7 +908,7 @@ export default grammar({
       seq(
         field('open_tag', $.jsx_opening_element),
         repeat($._jsx_child),
-        field('close_tag', $.jsx_closing_element),
+        field('close_tag', $.jsx_closing_element)
       ),
 
     jsx_fragment: ($) => seq('<', '>', repeat($._jsx_child), '<', '/', '>'),
@@ -916,7 +917,7 @@ export default grammar({
       seq(
         '{',
         optional(choice($._one_or_more_statements, $.spread_element)),
-        '}',
+        '}'
       ),
 
     _jsx_child: ($) =>
@@ -931,7 +932,7 @@ export default grammar({
         $.jsx_fragment,
         $.block,
         $.spread_element,
-        $.member_expression,
+        $.member_expression
       ),
 
     jsx_opening_element: ($) =>
@@ -941,8 +942,8 @@ export default grammar({
           '<',
           field('name', $._jsx_element_name),
           repeat(field('attribute', $._jsx_attribute)),
-          '>',
-        ),
+          '>'
+        )
       ),
 
     _jsx_identifier: ($) =>
@@ -954,8 +955,8 @@ export default grammar({
         seq(
           choice($._jsx_identifier, $.nested_jsx_identifier),
           '.',
-          $._jsx_identifier,
-        ),
+          $._jsx_identifier
+        )
       ),
 
     _jsx_element_name: ($) =>
@@ -970,7 +971,7 @@ export default grammar({
         field('name', $._jsx_element_name),
         repeat(field('attribute', $._jsx_attribute)),
         '/',
-        '>',
+        '>'
       ),
 
     _jsx_attribute_name: ($) =>
@@ -982,7 +983,7 @@ export default grammar({
       seq(
         optional('?'),
         $._jsx_attribute_name,
-        optional(seq('=', optional('?'), $._jsx_attribute_value)),
+        optional(seq('=', optional('?'), $._jsx_attribute_value))
       ),
 
     _jsx_attribute_value: ($) => choice($.primary_expression, $.jsx_expression),
@@ -998,7 +999,7 @@ export default grammar({
     decorator: ($) =>
       choice(
         alias($._decorator_inline, $.decorator_identifier),
-        seq(alias($._decorator, $.decorator_identifier), $.decorator_arguments),
+        seq(alias($._decorator, $.decorator_identifier), $.decorator_arguments)
       ),
 
     decorator_arguments: ($) =>
@@ -1011,8 +1012,8 @@ export default grammar({
           field('object', $.primary_expression),
           '[',
           field('index', $.expression),
-          ']',
-        ),
+          ']'
+        )
       ),
 
     member_expression: ($) =>
@@ -1025,13 +1026,13 @@ export default grammar({
             seq(
               field(
                 'module',
-                seq(repeat(seq($.module_identifier, '.')), $.module_identifier),
+                seq(repeat(seq($.module_identifier, '.')), $.module_identifier)
               ),
-              '.',
-            ),
+              '.'
+            )
           ),
-          field('property', alias($.value_identifier, $.property_identifier)),
-        ),
+          field('property', alias($.value_identifier, $.property_identifier))
+        )
       ),
 
     spread_element: ($) => seq('...', $.expression),
@@ -1043,8 +1044,8 @@ export default grammar({
           '?',
           field('consequence', $.expression),
           ':',
-          field('alternative', $.expression),
-        ),
+          field('alternative', $.expression)
+        )
       ),
 
     for_expression: ($) =>
@@ -1055,7 +1056,7 @@ export default grammar({
         $.expression,
         choice('to', 'downto'),
         $.expression,
-        $.block,
+        $.block
       ),
 
     while_expression: ($) => seq('while', $.expression, $.block),
@@ -1098,10 +1099,10 @@ export default grammar({
             seq(
               field('left', $.expression),
               field('operator', operator),
-              field('right', $.expression),
-            ),
-          ),
-        ),
+              field('right', $.expression)
+            )
+          )
+        )
       ),
 
     coercion_expression: ($) =>
@@ -1111,7 +1112,7 @@ export default grammar({
           seq(
             field('left', $.expression),
             field('operator', ':>'),
-            field('right', $._type),
+            field('right', $._type)
           ),
           seq(
             '(',
@@ -1119,9 +1120,9 @@ export default grammar({
             field('source_type', $.type_annotation),
             field('operator', ':>'),
             field('right', $._type),
-            ')',
-          ),
-        ),
+            ')'
+          )
+        )
       ),
 
     unary_expression: ($) =>
@@ -1136,9 +1137,9 @@ export default grammar({
         ].map(([operator, precedence]) =>
           prec.left(
             precedence,
-            seq(field('operator', operator), field('argument', $.expression)),
-          ),
-        ),
+            seq(field('operator', operator), field('argument', $.expression))
+          )
+        )
       ),
 
     extension_expression: ($) =>
@@ -1146,8 +1147,8 @@ export default grammar({
         seq(
           repeat1('%'),
           $.extension_identifier,
-          optional($._extension_expression_payload),
-        ),
+          optional($._extension_expression_payload)
+        )
       ),
 
     _extension_expression_payload: ($) =>
@@ -1157,8 +1158,8 @@ export default grammar({
       prec.right(
         seq(
           choice($.variant_identifier, $.nested_variant_identifier),
-          optional(alias($.variant_arguments, $.arguments)),
-        ),
+          optional(alias($.variant_arguments, $.arguments))
+        )
       ),
 
     nested_variant_identifier: ($) =>
@@ -1171,8 +1172,8 @@ export default grammar({
       prec.right(
         seq(
           $.polyvar_identifier,
-          optional(alias($.variant_arguments, $.arguments)),
-        ),
+          optional(alias($.variant_arguments, $.arguments))
+        )
       ),
 
     _type_identifier: ($) => choice($.type_identifier, $.type_identifier_path),
@@ -1184,7 +1185,7 @@ export default grammar({
       choice(
         $.module_primary_expression,
         $.module_type_of,
-        $.module_type_constraint,
+        $.module_type_constraint
       ),
 
     module_primary_expression: ($) =>
@@ -1193,7 +1194,7 @@ export default grammar({
         $.module_identifier,
         $.module_identifier_path,
         $.functor_use,
-        $.module_unpack,
+        $.module_unpack
       ),
 
     parenthesized_module_expression: ($) =>
@@ -1204,7 +1205,7 @@ export default grammar({
 
     module_type_of: ($) =>
       prec.left(
-        seq('module', 'type', 'of', choice($.module_expression, $.block)),
+        seq('module', 'type', 'of', choice($.module_expression, $.block))
       ),
 
     _module_type_constraint_with: ($) =>
@@ -1213,9 +1214,9 @@ export default grammar({
           'with',
           sep1(
             choice('and', 'with'),
-            choice($.constrain_module, $.constrain_type),
-          ),
-        ),
+            choice($.constrain_module, $.constrain_type)
+          )
+        )
       ),
 
     module_type_constraint: ($) =>
@@ -1227,9 +1228,9 @@ export default grammar({
             $.module_expression,
             $._module_type_constraint_with,
             ')',
-            $._module_type_constraint_with,
-          ),
-        ),
+            $._module_type_constraint_with
+          )
+        )
       ),
 
     constrain_module: ($) =>
@@ -1237,10 +1238,11 @@ export default grammar({
         'module',
         $.module_primary_expression,
         choice('=', ':='),
-        $.module_primary_expression,
+        $.module_primary_expression
       ),
 
-    constrain_type: ($) => seq('type', $._type, choice('=', ':='), optional('private'), $._type),
+    constrain_type: ($) =>
+      seq('type', $._type, choice('=', ':='), optional('private'), $._type),
 
     functor_use: ($) =>
       seq($.module_primary_expression, alias($.functor_arguments, $.arguments)),
@@ -1257,8 +1259,8 @@ export default grammar({
         '#',
         choice(
           /[a-zA-Z0-9_']+/,
-          seq(optional('\\'), alias($.string, $.polyvar_string)),
-        ),
+          seq(optional('\\'), alias($.string, $.polyvar_string))
+        )
       ),
 
     type_identifier: ($) =>
@@ -1280,7 +1282,7 @@ export default grammar({
         '/',
         field('pattern', $.regex_pattern),
         token.immediate(prec(1, '/')),
-        optional(field('flags', $.regex_flags)),
+        optional(field('flags', $.regex_flags))
       ),
 
     regex_pattern: (_) =>
@@ -1291,10 +1293,10 @@ export default grammar({
             choice(
               seq('[', repeat(choice(seq('\\', /./), /[^\]\n\\]/)), ']'),
               seq('\\', /./),
-              /[^/\\\[\n]/,
-            ),
-          ),
-        ),
+              /[^/\\\[\n]/
+            )
+          )
+        )
       ),
 
     regex_flags: (_) => token.immediate(/[a-z]+/),
@@ -1303,27 +1305,27 @@ export default grammar({
       // OCaml: https://github.com/tree-sitter/tree-sitter-ocaml/blob/f1106bf834703f1f2f795da1a3b5f8f40174ffcc/ocaml/grammar.js#L26
       const hex_literal = seq(
         optional(choice('-', '+')),
-        /0[xX][0-9A-Fa-f][0-9A-Fa-f_]*(\.[0-9A-Fa-f_]*)?([pP][+\-]?[0-9][0-9_]*)?[g-zG-Z]?/,
-      );
+        /0[xX][0-9A-Fa-f][0-9A-Fa-f_]*(\.[0-9A-Fa-f_]*)?([pP][+\-]?[0-9][0-9_]*)?[g-zG-Z]?/
+      )
 
-      const decimal_digits = /\d(_?\d)*/;
-      const signed_integer = seq(optional(choice('-', '+')), decimal_digits);
-      const exponent_part = seq(choice('e', 'E'), signed_integer);
+      const decimal_digits = /\d(_?\d)*/
+      const signed_integer = seq(optional(choice('-', '+')), decimal_digits)
+      const exponent_part = seq(choice('e', 'E'), signed_integer)
 
-      const binary_literal = seq(choice('0b', '0B'), /[0-1](_?[0-1])*/);
+      const binary_literal = seq(choice('0b', '0B'), /[0-1](_?[0-1])*/)
 
-      const octal_literal = seq(choice('0o', '0O'), /[0-7](_?[0-7])*/);
+      const octal_literal = seq(choice('0o', '0O'), /[0-7](_?[0-7])*/)
 
       const bigint_literal = seq(
         optional(choice('-', '+')),
         choice(hex_literal, binary_literal, octal_literal, decimal_digits),
-        'n',
-      );
+        'n'
+      )
 
       const decimal_integer_literal = choice(
         repeat1('0'),
-        seq(repeat('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits))),
-      );
+        seq(repeat('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits)))
+      )
 
       const decimal_literal = seq(
         optional(choice('-', '+')),
@@ -1332,13 +1334,13 @@ export default grammar({
             decimal_integer_literal,
             '.',
             optional(decimal_digits),
-            optional(exponent_part),
+            optional(exponent_part)
           ),
           seq('.', decimal_digits, optional(exponent_part)),
           seq(decimal_integer_literal, exponent_part),
-          decimal_digits,
-        ),
-      );
+          decimal_digits
+        )
+      )
 
       const int_32_64 = seq(
         optional(choice('-', '+')),
@@ -1346,10 +1348,10 @@ export default grammar({
           decimal_integer_literal,
           binary_literal,
           octal_literal,
-          hex_literal,
+          hex_literal
         ),
-        choice('L', 'l'),
-      );
+        choice('L', 'l')
+      )
 
       return token(
         choice(
@@ -1358,9 +1360,9 @@ export default grammar({
           binary_literal,
           octal_literal,
           bigint_literal,
-          int_32_64,
-        ),
-      );
+          int_32_64
+        )
+      )
     },
 
     unit: ($) => seq('(', ')'),
@@ -1375,10 +1377,10 @@ export default grammar({
         repeat(
           choice(
             alias($.unescaped_double_string_fragment, $.string_fragment),
-            $.escape_sequence,
-          ),
+            $.escape_sequence
+          )
         ),
-        '"',
+        '"'
       ),
 
     // Workaround to https://github.com/tree-sitter/tree-sitter/issues/1156
@@ -1397,9 +1399,9 @@ export default grammar({
             /[0-7]{1,3}/,
             /x[0-9a-fA-F]{2}/,
             /u[0-9a-fA-F]{4}/,
-            /u\{[0-9a-fA-F]+\}/,
-          ),
-        ),
+            /u\{[0-9a-fA-F]+\}/
+          )
+        )
       ),
 
     template_string: ($) =>
@@ -1410,14 +1412,14 @@ export default grammar({
               choice(
                 /[a-z_][a-zA-Z0-9_']*/,
                 // escape_sequence
-                seq('\\"', /[^"]+/, '"'),
-              ),
+                seq('\\"', /[^"]+/, '"')
+              )
             ),
-            '`',
-          ),
+            '`'
+          )
         ),
         optional($.template_string_content),
-        '`',
+        '`'
       ),
 
     template_string_content: ($) =>
@@ -1426,15 +1428,15 @@ export default grammar({
           $._template_chars,
           $.template_substitution,
           /\s/,
-          choice(alias('\\`', $.escape_sequence), $.escape_sequence),
-        ),
+          choice(alias('\\`', $.escape_sequence), $.escape_sequence)
+        )
       ),
 
     template_substitution: ($) =>
       choice(seq('$', $.value_identifier), seq('${', $.expression, '}')),
 
     character: ($) =>
-      seq('\'', repeat(choice(/[^\\']/, $.escape_sequence)), '\''),
+      seq("'", repeat(choice(/[^\\']/, $.escape_sequence)), "'"),
 
     _unescaped_template_string_fragment: ($) =>
       token.immediate(prec(1, /[^`\\\$]+/)),
@@ -1445,7 +1447,7 @@ export default grammar({
 
     _reserved_identifier: ($) => choice('async', 'unpack'),
   },
-});
+})
 
 /**
  * Creates a rule that matches one or more rules separated by vertical bars.
@@ -1455,7 +1457,7 @@ export default grammar({
  * @returns {SeqRule}
  */
 function barSep1(rule) {
-  return seq(rule, repeat(seq('|', rule)));
+  return seq(rule, repeat(seq('|', rule)))
 }
 
 /**
@@ -1466,7 +1468,7 @@ function barSep1(rule) {
  * @returns {SeqRule}
  */
 function commaSep1(rule) {
-  return seq(rule, repeat(seq(',', rule)));
+  return seq(rule, repeat(seq(',', rule)))
 }
 
 /**
@@ -1477,7 +1479,7 @@ function commaSep1(rule) {
  * @returns {SeqRule}
  */
 function commaSep2(rule) {
-  return seq(rule, ',', commaSep1(rule));
+  return seq(rule, ',', commaSep1(rule))
 }
 
 /**
@@ -1488,7 +1490,7 @@ function commaSep2(rule) {
  * @returns {SeqRule}
  */
 function commaSep1t(rule) {
-  return seq(commaSep1(rule), optional(','));
+  return seq(commaSep1(rule), optional(','))
 }
 
 /**
@@ -1499,7 +1501,7 @@ function commaSep1t(rule) {
  * @returns {SeqRule}
  */
 function commaSep2t(rule) {
-  return seq(commaSep2(rule), optional(','));
+  return seq(commaSep2(rule), optional(','))
 }
 
 /**
@@ -1510,7 +1512,7 @@ function commaSep2t(rule) {
  * @returns {ChoiceRule}
  */
 function commaSept(rule) {
-  return optional(commaSep1t(rule));
+  return optional(commaSep1t(rule))
 }
 
 /**
@@ -1522,7 +1524,7 @@ function commaSept(rule) {
  * @returns {SeqRule}
  */
 function sep1(delimiter, rule) {
-  return seq(rule, repeat(seq(delimiter, rule)));
+  return seq(rule, repeat(seq(delimiter, rule)))
 }
 
 /**
@@ -1534,7 +1536,7 @@ function sep1(delimiter, rule) {
  * @returns {ChoiceRule}
  */
 function path(prefix, final) {
-  return choice(final, seq(prefix, '.', final));
+  return choice(final, seq(prefix, '.', final))
 }
 
 /**
@@ -1545,5 +1547,5 @@ function path(prefix, final) {
  * @returns {SeqRule}
  */
 function parenthesize(rule) {
-  return seq('(', rule, ')');
+  return seq('(', rule, ')')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "eslint-config-treesitter": "^1.0.2",
+        "prettier": "3.9.5",
         "rescript": "^12.1.0",
         "tree-sitter": "^0.25.0",
         "tree-sitter-cli": "^0.26.11"
@@ -52,6 +53,7 @@
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -71,6 +73,7 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -84,6 +87,7 @@
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -94,6 +98,7 @@
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -109,6 +114,7 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -122,6 +128,7 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -135,6 +142,7 @@
       "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.14.0",
         "debug": "^4.3.2",
@@ -159,6 +167,7 @@
       "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -172,6 +181,7 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -182,6 +192,7 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -196,6 +207,7 @@
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanfs/types": "^0.15.0"
       },
@@ -209,6 +221,7 @@
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.2",
         "@humanfs/types": "^0.15.0",
@@ -224,6 +237,7 @@
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -234,6 +248,7 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -248,6 +263,7 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -354,7 +370,8 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.63.0",
@@ -376,7 +393,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -400,6 +416,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -417,6 +434,7 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -442,14 +460,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
@@ -457,6 +477,7 @@
       "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -468,6 +489,7 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -478,6 +500,7 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -495,6 +518,7 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -507,7 +531,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/comment-parser": {
       "version": "1.4.1",
@@ -524,7 +549,8 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -532,6 +558,7 @@
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -564,7 +591,8 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -684,6 +712,7 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -745,6 +774,7 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -768,6 +798,7 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -777,21 +808,24 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -799,6 +833,7 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -812,6 +847,7 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -829,6 +865,7 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -842,7 +879,8 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -850,6 +888,7 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -863,6 +902,7 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -876,6 +916,7 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -886,6 +927,7 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -896,6 +938,7 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -913,6 +956,7 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -923,6 +967,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -933,6 +978,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -945,7 +991,8 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -963,6 +1010,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -985,21 +1033,24 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -1007,6 +1058,7 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -1017,6 +1069,7 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -1031,6 +1084,7 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -1046,7 +1100,8 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -1054,6 +1109,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1079,7 +1135,8 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-addon-api": {
       "version": "8.3.1",
@@ -1107,6 +1164,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -1125,6 +1183,7 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -1141,6 +1200,7 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -1157,6 +1217,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1187,6 +1248,7 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1197,6 +1259,7 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1207,8 +1270,25 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -1217,6 +1297,7 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1264,6 +1345,7 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -1287,6 +1369,7 @@
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -1300,6 +1383,7 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1335,6 +1419,7 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -1348,6 +1433,7 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1387,6 +1473,7 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -1400,6 +1487,7 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -1410,6 +1498,7 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1426,6 +1515,7 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1436,6 +1526,7 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,10 @@
         "node-gyp-build": "^4.8.2"
       },
       "devDependencies": {
+        "eslint-config-treesitter": "^1.0.2",
         "rescript": "^12.1.0",
         "tree-sitter": "^0.25.0",
-        "tree-sitter-cli": "^0.26.3"
+        "tree-sitter-cli": "^0.26.11"
       },
       "peerDependencies": {
         "tree-sitter": "^0.21.1"
@@ -26,6 +27,233 @@
         "tree-sitter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
+      "integrity": "sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6",
+        "@typescript-eslint/types": "^8.11.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@rescript/darwin-arm64": {
@@ -114,10 +342,743 @@
         "node": ">=20.11.0"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-treesitter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-treesitter/-/eslint-config-treesitter-1.0.2.tgz",
+      "integrity": "sha512-OkzjA0oaNgYUFkGmo9T2cvRE7cxzh1dgSt0laO8Hdcypp9di8lebldoPivALXFusRb7s54J5exIw1w7l+g85Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-jsdoc": "^50.2.4"
+      },
+      "peerDependencies": {
+        "eslint": ">= 9"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "50.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.8.0.tgz",
+      "integrity": "sha512-UyGb5755LMFWPrZTEqqvTJ3urLz1iqj+bYOHFNag+sw3NvaMWP9K2z+uIn37XfNALmQLQyrBlJ5mkiVPL7ADEg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.50.2",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.1",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
+      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nan": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
       "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
@@ -138,6 +1099,126 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rescript": {
@@ -177,6 +1258,103 @@
         "@rescript/win32-x64": "12.1.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tree-sitter": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
@@ -190,9 +1368,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.10.tgz",
-      "integrity": "sha512-RTse32x5YWOrEtH7wos8ODt3yyB7SKgmGN70jC7R+WcnDA64vrpYU98+LnwrwdXMlxgr0LGQdezZz85DN8Wv0w==",
+      "version": "0.26.11",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.11.tgz",
+      "integrity": "sha512-/hRCA0Ehkgk6B5WTYSiENk1R2Zv3LJcfvL3wjofzx+EYaKySZDu0agGRQcccay9Lg7wxJWsDa9cTRS92wsM5gQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -201,6 +1379,68 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "update-tests": "tree-sitter test --update"
   },
   "prettier": {
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "tabWidth": 2,
-    "semi": false,
+    "semi": true,
     "singleQuote": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "eslint-config-treesitter": "^1.0.2",
+    "prettier": "3.9.5",
     "rescript": "^12.1.0",
     "tree-sitter": "^0.25.0",
     "tree-sitter-cli": "^0.26.11"
@@ -26,11 +27,20 @@
   },
   "scripts": {
     "lint": "eslint grammar.js",
+    "format": "prettier grammar.js --write",
+    "checkformat": "prettier grammar.js --check",
     "install": "node-gyp-build",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",
     "test": "tree-sitter test",
     "parse": "tree-sitter parse",
-    "generate": "tree-sitter generate"
+    "generate": "tree-sitter generate",
+    "update-tests": "tree-sitter test --update"
+  },
+  "prettier": {
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "node-gyp-build": "^4.8.2"
   },
   "devDependencies": {
+    "eslint-config-treesitter": "^1.0.2",
     "rescript": "^12.1.0",
     "tree-sitter": "^0.25.0",
-    "tree-sitter-cli": "^0.26.3"
+    "tree-sitter-cli": "^0.26.11"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.1"
@@ -24,6 +25,7 @@
     }
   },
   "scripts": {
+    "lint": "eslint grammar.js",
     "install": "node-gyp-build",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",

--- a/src/parser.c
+++ b/src/parser.c
@@ -7413,7 +7413,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) ADVANCE(185);
-      if (lookahead != 0) ADVANCE(186);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(186);
       END_STATE();
     case 2:
       ADVANCE_MAP(
@@ -8085,18 +8087,24 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) ADVANCE(208);
-      if (lookahead != 0) ADVANCE(210);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(210);
       END_STATE();
     case 23:
       if (lookahead == '"') ADVANCE(86);
       END_STATE();
     case 24:
       if (lookahead == '"') ADVANCE(182);
-      if (lookahead != 0) ADVANCE(24);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(24);
       END_STATE();
     case 25:
       if (lookahead == '"') ADVANCE(181);
-      if (lookahead != 0) ADVANCE(25);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(25);
       END_STATE();
     case 26:
       if (lookahead == '"') ADVANCE(87);
@@ -8184,7 +8192,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) ADVANCE(224);
-      if (lookahead != 0) ADVANCE(222);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(222);
       END_STATE();
     case 33:
       ADVANCE_MAP(
@@ -8307,7 +8317,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\\') ADVANCE(84);
       if (lookahead == ']') ADVANCE(186);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(51);
+          lookahead != '\n' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(51);
       END_STATE();
     case 52:
       if (lookahead == '^') ADVANCE(151);
@@ -8338,13 +8350,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'u') ADVANCE(59);
       if (lookahead == 'x') ADVANCE(83);
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(213);
-      if (lookahead != 0) ADVANCE(211);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(211);
       END_STATE();
     case 58:
       if (lookahead == 'u') ADVANCE(59);
       if (lookahead == 'x') ADVANCE(83);
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(213);
-      if (lookahead != 0) ADVANCE(211);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(211);
       END_STATE();
     case 59:
       if (lookahead == '{') ADVANCE(81);
@@ -8469,19 +8485,27 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 84:
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(51);
+          lookahead != '\n' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(51);
       END_STATE();
     case 85:
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(186);
+          lookahead != '\n' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(186);
       END_STATE();
     case 86:
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(24);
+          lookahead != '"' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(24);
       END_STATE();
     case 87:
       if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(25);
+          lookahead != '"' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(25);
       END_STATE();
     case 88:
       if (eof) ADVANCE(90);
@@ -8578,7 +8602,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 92:
       ACCEPT_TOKEN(sym_line_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(92);
+          lookahead != '\n' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(92);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(anon_sym_LBRACE);
@@ -8973,7 +8999,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 0x200b ||
           lookahead == 0x2060 ||
           lookahead == 0xfeff) ADVANCE(185);
-      if (lookahead != 0) ADVANCE(186);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(186);
       END_STATE();
     case 186:
       ACCEPT_TOKEN(sym_regex_pattern);
@@ -8981,7 +9009,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\\') ADVANCE(85);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '/') ADVANCE(186);
+          lookahead != '/' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(186);
       END_STATE();
     case 187:
       ACCEPT_TOKEN(sym_regex_flags);
@@ -9166,7 +9196,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') ADVANCE(210);
       if (lookahead != 0 &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(207);
+          lookahead != '\\' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(207);
       END_STATE();
     case 208:
       ACCEPT_TOKEN(sym_unescaped_double_string_fragment);
@@ -9179,20 +9211,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 0xfeff) ADVANCE(208);
       if (lookahead != 0 &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(210);
+          lookahead != '\\' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(210);
       END_STATE();
     case 209:
       ACCEPT_TOKEN(sym_unescaped_double_string_fragment);
       if (lookahead == '/') ADVANCE(207);
       if (lookahead != 0 &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(210);
+          lookahead != '\\' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(210);
       END_STATE();
     case 210:
       ACCEPT_TOKEN(sym_unescaped_double_string_fragment);
       if (lookahead != 0 &&
           lookahead != '"' &&
-          lookahead != '\\') ADVANCE(210);
+          lookahead != '\\' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(210);
       END_STATE();
     case 211:
       ACCEPT_TOKEN(sym_escape_sequence);
@@ -9255,7 +9293,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 0xfeff) ADVANCE(224);
       if (lookahead != 0 &&
           lookahead != '\'' &&
-          lookahead != '\\') ADVANCE(222);
+          lookahead != '\\' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(222);
       END_STATE();
     default:
       return false;

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -50,12 +50,18 @@ extern "C" {
 /// memory allocated for the array's contents.
 #define array_clear(self) ((self)->size = 0)
 
+#ifdef __cplusplus
+#define _array__cast(self, expr) (decltype((self)->contents))(expr)
+#else
+#define _array__cast(self, expr) (expr)
+#endif
+
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity)        \
-  ((self)->contents = _array__reserve(           \
-    (void *)(self)->contents, &(self)->capacity, \
-    array_elem_size(self), new_capacity)         \
+#define array_reserve(self, new_capacity)                 \
+  ((self)->contents = _array__cast(self, _array__reserve( \
+    (void *)(self)->contents, &(self)->capacity,          \
+    array_elem_size(self), new_capacity))                 \
   )
 
 /// Free any memory allocated for this array. Note that this does not free any
@@ -71,10 +77,10 @@ extern "C" {
 /// Push a new `element` onto the end of the array.
 #define array_push(self, element)                                 \
   do {                                                            \
-    (self)->contents = _array__grow(                              \
+    (self)->contents = _array__cast(self, _array__grow(           \
       (void *)(self)->contents, (self)->size, &(self)->capacity,  \
       1, array_elem_size(self)                                    \
-    );                                                            \
+    ));                                                           \
    (self)->contents[(self)->size++] = (element);                  \
   } while(0)
 
@@ -83,10 +89,10 @@ extern "C" {
 #define array_grow_by(self, count)                                               \
   do {                                                                           \
     if ((count) == 0) break;                                                     \
-    (self)->contents = _array__grow(                                             \
+    (self)->contents = _array__cast(self, _array__grow(                          \
       (self)->contents, (self)->size, &(self)->capacity,                         \
       count, array_elem_size(self)                                               \
-    );                                                                           \
+    ));                                                                          \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
     (self)->size += (count);                                                     \
   } while (0)
@@ -98,26 +104,26 @@ extern "C" {
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
 #define array_extend(self, count, other_contents)                 \
-  (self)->contents = _array__splice(                              \
+  ((self)->contents = _array__cast(self, _array__splice(          \
     (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
     array_elem_size(self), (self)->size, 0, count, other_contents \
-  )
+  )))
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
 #define array_splice(self, _index, old_count, new_count, new_contents) \
-  (self)->contents = _array__splice(                                   \
+  ((self)->contents = _array__cast(self, _array__splice(              \
     (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
     array_elem_size(self), _index, old_count, new_count, new_contents  \
-  )
+  )))
 
 /// Insert one `element` into the array at the given `index`.
 #define array_insert(self, _index, element)                     \
-  (self)->contents = _array__splice(                            \
+  ((self)->contents = _array__cast(self, _array__splice(        \
     (void *)(self)->contents, &(self)->size, &(self)->capacity, \
     array_elem_size(self), _index, 0, 1, &(element)             \
-  )
+  )))
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
@@ -128,17 +134,17 @@ extern "C" {
 
 /// Assign the contents of one array to another, reallocating if necessary.
 #define array_assign(self, other)                                   \
-  (self)->contents = _array__assign(                                \
+  ((self)->contents = _array__cast(self, _array__assign(            \
     (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
     (const void *)(other)->contents, (other)->size, array_elem_size(self) \
-  )
+  )))
 
 /// Swap one array with another
 #define array_swap(self, other)                                     \
   do {                                                              \
     void *_array_swap_tmp = (void *)(self)->contents;               \
     (self)->contents = (other)->contents;                           \
-    (other)->contents = _array_swap_tmp;                            \
+    (other)->contents = _array__cast(other, _array_swap_tmp);       \
     _array__swap(&(self)->size, &(self)->capacity,                  \
                  &(other)->size, &(other)->capacity);               \
   } while (0)


### PR DESCRIPTION
## Summary

This PR standardizes the code quality tooling used for `grammar.js` and enforces it in CI.

## Changes

- Add the official Tree-sitter ESLint configuration.
- Add Prettier configuration and formatting scripts.
- Format `grammar.js` consistently with single quotes and trailing commas.
- Add JSDoc types and behavior descriptions for grammar helper functions.
- Add a lint workflow that checks ESLint, formatting, and generated parser consistency.
- Update the Tree-sitter CLI and regenerate parser artifacts.
- Update GitHub Actions and use Node.js 22 for compatibility.
- Configure consistent indentation for corpus test files.
- Add an `update-tests` script for refreshing corpus expectations.